### PR TITLE
Set up basic TabView structure

### DIFF
--- a/VetAI/ContentView.swift
+++ b/VetAI/ContentView.swift
@@ -1,88 +1,26 @@
-//
-//  ContentView.swift
-//  VetAI
-//
-//  Created by Olivia on 7/23/25.
-//
-
 import SwiftUI
-import CoreData
 
 struct ContentView: View {
-    @Environment(\.managedObjectContext) private var viewContext
-
-    @FetchRequest(
-        sortDescriptors: [NSSortDescriptor(keyPath: \Item.timestamp, ascending: true)],
-        animation: .default)
-    private var items: FetchedResults<Item>
-
     var body: some View {
-        NavigationView {
-            List {
-                ForEach(items) { item in
-                    NavigationLink {
-                        Text("Item at \(item.timestamp!, formatter: itemFormatter)")
-                    } label: {
-                        Text(item.timestamp!, formatter: itemFormatter)
-                    }
+        TabView {
+            HomeView()
+                .tabItem {
+                    Label("Home", systemImage: "house")
                 }
-                .onDelete(perform: deleteItems)
-            }
-            .toolbar {
-#if os(iOS)
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    EditButton()
+
+            ScanView()
+                .tabItem {
+                    Label("Scan", systemImage: "camera")
                 }
-#endif
-                ToolbarItem {
-                    Button(action: addItem) {
-                        Label("Add Item", systemImage: "plus")
-                    }
+
+            ProfileView()
+                .tabItem {
+                    Label("Profile", systemImage: "person")
                 }
-            }
-            Text("Select an item")
-        }
-    }
-
-    private func addItem() {
-        withAnimation {
-            let newItem = Item(context: viewContext)
-            newItem.timestamp = Date()
-
-            do {
-                try viewContext.save()
-            } catch {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                let nsError = error as NSError
-                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
-            }
-        }
-    }
-
-    private func deleteItems(offsets: IndexSet) {
-        withAnimation {
-            offsets.map { items[$0] }.forEach(viewContext.delete)
-
-            do {
-                try viewContext.save()
-            } catch {
-                // Replace this implementation with code to handle the error appropriately.
-                // fatalError() causes the application to generate a crash log and terminate. You should not use this function in a shipping application, although it may be useful during development.
-                let nsError = error as NSError
-                fatalError("Unresolved error \(nsError), \(nsError.userInfo)")
-            }
         }
     }
 }
 
-private let itemFormatter: DateFormatter = {
-    let formatter = DateFormatter()
-    formatter.dateStyle = .short
-    formatter.timeStyle = .medium
-    return formatter
-}()
-
 #Preview {
-    ContentView().environment(\.managedObjectContext, PersistenceController.preview.container.viewContext)
+    ContentView()
 }

--- a/VetAI/HomeView.swift
+++ b/VetAI/HomeView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct HomeView: View {
+    var body: some View {
+        Text("Home Screen")
+            .padding()
+    }
+}
+
+#Preview {
+    HomeView()
+}

--- a/VetAI/ProfileView.swift
+++ b/VetAI/ProfileView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct ProfileView: View {
+    var body: some View {
+        Text("Profile Screen")
+            .padding()
+    }
+}
+
+#Preview {
+    ProfileView()
+}

--- a/VetAI/ScanView.swift
+++ b/VetAI/ScanView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct ScanView: View {
+    var body: some View {
+        Text("Scan Screen")
+            .padding()
+    }
+}
+
+#Preview {
+    ScanView()
+}

--- a/VetAI/VetAIApp.swift
+++ b/VetAI/VetAIApp.swift
@@ -1,21 +1,10 @@
-//
-//  VetAIApp.swift
-//  VetAI
-//
-//  Created by Olivia on 7/23/25.
-// olivia
-
 import SwiftUI
 
 @main
-
 struct VetAIApp: App {
-    let persistenceController = PersistenceController.shared
-
     var body: some Scene {
         WindowGroup {
             ContentView()
-                .environment(\.managedObjectContext, persistenceController.container.viewContext)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Replace ContentView with TabView hosting Home, Scan, and Profile sections
- Add placeholder HomeView, ScanView, and ProfileView components
- Simplify app entry to launch ContentView without persistence layer

## Testing
- `swift test` (fails: Could not find Package.swift)

------
https://chatgpt.com/codex/tasks/task_e_689428212fd883249581c851b5e29103