### PR TITLE
Add diagnosis history and detail views

### DIFF
--- a/VetAI/ContentView.swift
+++ b/VetAI/ContentView.swift
@@ -1,16 +1,18 @@
 import SwiftUI
 
 struct ContentView: View {
+    @State private var diagnosisHistory: [DiagnosisRecord] = []
+
     var body: some View {
         TabView {
-            HomeView()
+            HomeView(diagnosisHistory: $diagnosisHistory)
                 .tabItem {
                     Label("Home", systemImage: "house")
                 }
 
-            ScanView()
+            ScanView(diagnosisHistory: $diagnosisHistory)
                 .tabItem {
-                    Label("Scan", systemImage: "camera")
+                    Label("AI Diagnosis", systemImage: "stethoscope")
                 }
 
             ProfileView()

--- a/VetAI/DiagnosisDetailView.swift
+++ b/VetAI/DiagnosisDetailView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct DiagnosisDetailView: View {
+    let record: DiagnosisRecord
+
+    var body: some View {
+        Form {
+            Section(header: Text("Inputs")) {
+                HStack { Text("Species"); Spacer(); Text(record.species) }
+                HStack { Text("Symptoms"); Spacer(); Text(record.symptoms) }
+                HStack { Text("WBC"); Spacer(); Text(record.wbc) }
+                HStack { Text("RBC"); Spacer(); Text(record.rbc) }
+                HStack { Text("Glucose"); Spacer(); Text(record.glucose) }
+            }
+            Section(header: Text("Diagnosis")) {
+                HStack { Text("Result"); Spacer(); Text(record.diagnosisResult) }
+                HStack { Text("Confidence"); Spacer(); Text(record.confidence) }
+            }
+        }
+        .navigationTitle("Diagnosis Detail")
+    }
+}
+
+#Preview {
+    DiagnosisDetailView(record: DiagnosisRecord(species: "dog", symptoms: "lethargy", wbc: "5", rbc: "4", glucose: "100", diagnosisResult: "Possible anemia", confidence: "70%"))
+}

--- a/VetAI/DiagnosisRecord.swift
+++ b/VetAI/DiagnosisRecord.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct DiagnosisRecord: Identifiable {
+    let id = UUID()
+    let species: String
+    let symptoms: String
+    let wbc: String
+    let rbc: String
+    let glucose: String
+    let diagnosisResult: String
+    let confidence: String
+}
+

--- a/VetAI/HomeView.swift
+++ b/VetAI/HomeView.swift
@@ -1,12 +1,27 @@
 import SwiftUI
 
 struct HomeView: View {
+    @Binding var diagnosisHistory: [DiagnosisRecord]
+
     var body: some View {
-        Text("Home Screen")
-            .padding()
+        NavigationStack {
+            List(diagnosisHistory) { record in
+                NavigationLink(destination: DiagnosisDetailView(record: record)) {
+                    VStack(alignment: .leading) {
+                        Text(record.species)
+                        Text(record.diagnosisResult)
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+            .navigationTitle("History")
+        }
     }
 }
 
 #Preview {
-    HomeView()
+    HomeView(diagnosisHistory: .constant([
+        DiagnosisRecord(species: "dog", symptoms: "lethargy", wbc: "5", rbc: "4", glucose: "100", diagnosisResult: "Possible anemia", confidence: "70%")
+    ]))
 }

--- a/VetAI/ScanView.swift
+++ b/VetAI/ScanView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 
 struct ScanView: View {
+    @Binding var diagnosisHistory: [DiagnosisRecord]
     @State private var species: String = "dog"
     @State private var symptoms: String = ""
     @State private var wbc: String = ""
@@ -37,6 +38,17 @@ struct ScanView: View {
                     diagnosis = "No specific diagnosis"
                     confidence = "N/A"
                 }
+
+                let record = DiagnosisRecord(
+                    species: species,
+                    symptoms: symptoms,
+                    wbc: wbc,
+                    rbc: rbc,
+                    glucose: glucose,
+                    diagnosisResult: diagnosis,
+                    confidence: confidence
+                )
+                diagnosisHistory.append(record)
             }
 
             if !diagnosis.isEmpty {
@@ -50,5 +62,5 @@ struct ScanView: View {
 }
 
 #Preview {
-    ScanView()
+    ScanView(diagnosisHistory: .constant([]))
 }


### PR DESCRIPTION
## Summary
- Rename Scan tab to AI Diagnosis with stethoscope icon
- Save form inputs and results into DiagnosisRecord and show history
- Add detailed view for previous diagnoses

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689505e6ff74832481958a656bdbbc87