### PR TITLE
Add tab selection binding and start new diagnosis button

### DIFF
--- a/VetAI/ContentView.swift
+++ b/VetAI/ContentView.swift
@@ -2,23 +2,27 @@ import SwiftUI
 
 struct ContentView: View {
     @State private var diagnosisHistory: [DiagnosisRecord] = []
+    @State private var selectedTab = 0
 
     var body: some View {
-        TabView {
-            HomeView(diagnosisHistory: $diagnosisHistory)
+        TabView(selection: $selectedTab) {
+            HomeView(diagnosisHistory: $diagnosisHistory, selectedTab: $selectedTab)
                 .tabItem {
                     Label("Home", systemImage: "house")
                 }
+                .tag(0)
 
             ScanView(diagnosisHistory: $diagnosisHistory)
                 .tabItem {
                     Label("AI Diagnosis", systemImage: "stethoscope")
                 }
+                .tag(1)
 
             ProfileView()
                 .tabItem {
                     Label("Profile", systemImage: "person")
                 }
+                .tag(2)
         }
     }
 }

--- a/VetAI/HomeView.swift
+++ b/VetAI/HomeView.swift
@@ -2,35 +2,44 @@ import SwiftUI
 
 struct HomeView: View {
     @Binding var diagnosisHistory: [DiagnosisRecord]
+    @Binding var selectedTab: Int
 
     var body: some View {
         NavigationStack {
-            List {
-                Section {
-                    Text("Welcome back, Olivia!")
-                }
-
-                if let lastRecord = diagnosisHistory.last {
+            VStack {
+                List {
                     Section {
-                        VStack(alignment: .leading) {
-                            Text(lastRecord.species)
-                            Text(lastRecord.diagnosisResult)
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
+                        Text("Welcome back, Olivia!")
+                    }
+
+                    if let lastRecord = diagnosisHistory.last {
+                        Section {
+                            VStack(alignment: .leading) {
+                                Text(lastRecord.species)
+                                Text(lastRecord.diagnosisResult)
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                            }
+                        }
+                    }
+
+                    ForEach(diagnosisHistory) { record in
+                        NavigationLink(destination: DiagnosisDetailView(record: record)) {
+                            VStack(alignment: .leading) {
+                                Text(record.species)
+                                Text(record.diagnosisResult)
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                            }
                         }
                     }
                 }
 
-                ForEach(diagnosisHistory) { record in
-                    NavigationLink(destination: DiagnosisDetailView(record: record)) {
-                        VStack(alignment: .leading) {
-                            Text(record.species)
-                            Text(record.diagnosisResult)
-                                .font(.subheadline)
-                                .foregroundColor(.secondary)
-                        }
-                    }
+                Button("Start New Diagnosis") {
+                    selectedTab = 1
                 }
+                .buttonStyle(.borderedProminent)
+                .padding()
             }
             .navigationTitle("History")
         }
@@ -38,7 +47,18 @@ struct HomeView: View {
 }
 
 #Preview {
-    HomeView(diagnosisHistory: .constant([
-        DiagnosisRecord(species: "dog", symptoms: "lethargy", wbc: "5", rbc: "4", glucose: "100", diagnosisResult: "Possible anemia", confidence: "70%")
-    ]))
+    HomeView(
+        diagnosisHistory: .constant([
+            DiagnosisRecord(
+                species: "dog",
+                symptoms: "lethargy",
+                wbc: "5",
+                rbc: "4",
+                glucose: "100",
+                diagnosisResult: "Possible anemia",
+                confidence: "70%"
+            )
+        ]),
+        selectedTab: .constant(0)
+    )
 }


### PR DESCRIPTION
## Summary
- Track the active tab in `ContentView` with `selectedTab` state and tag each tab for programmatic switching.
- Expose `selectedTab` binding in `HomeView` and add a “Start New Diagnosis” button that navigates to AI Diagnosis.

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68992a8cbeec83249dd712256c508135