### PR TITLE
Refactor diagnosis history state to use AppState

### DIFF
--- a/VetAI/ContentView.swift
+++ b/VetAI/ContentView.swift
@@ -1,18 +1,17 @@
 import SwiftUI
 
 struct ContentView: View {
-    @State private var diagnosisHistory: [DiagnosisRecord] = []
     @State private var selectedTab = 0
 
     var body: some View {
         TabView(selection: $selectedTab) {
-            HomeView(diagnosisHistory: $diagnosisHistory, selectedTab: $selectedTab)
+            HomeView(selectedTab: $selectedTab)
                 .tabItem {
                     Label("Home", systemImage: "house")
                 }
                 .tag(0)
 
-            ScanView(diagnosisHistory: $diagnosisHistory)
+            ScanView()
                 .tabItem {
                     Label("AI Diagnosis", systemImage: "stethoscope")
                 }
@@ -28,5 +27,5 @@ struct ContentView: View {
 }
 
 #Preview {
-    ContentView()
+    ContentView().environmentObject(AppState())
 }

--- a/VetAI/HomeView.swift
+++ b/VetAI/HomeView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct HomeView: View {
-    @Binding var diagnosisHistory: [DiagnosisRecord]
+    @EnvironmentObject var appState: AppState
     @Binding var selectedTab: Int
 
     var body: some View {
@@ -12,7 +12,7 @@ struct HomeView: View {
                         Text("Welcome back, Olivia!")
                     }
 
-                    if let lastRecord = diagnosisHistory.last {
+                    if let lastRecord = appState.diagnosisHistory.last {
                         Section {
                             VStack(alignment: .leading) {
                                 Text(lastRecord.species)
@@ -23,7 +23,7 @@ struct HomeView: View {
                         }
                     }
 
-                    ForEach(diagnosisHistory) { record in
+                    ForEach(appState.diagnosisHistory) { record in
                         NavigationLink(destination: DiagnosisDetailView(record: record)) {
                             VStack(alignment: .leading) {
                                 Text(record.species)
@@ -47,18 +47,17 @@ struct HomeView: View {
 }
 
 #Preview {
-    HomeView(
-        diagnosisHistory: .constant([
-            DiagnosisRecord(
-                species: "dog",
-                symptoms: "lethargy",
-                wbc: "5",
-                rbc: "4",
-                glucose: "100",
-                result: "Possible anemia",
-                confidence: "70%"
-            )
-        ]),
-        selectedTab: .constant(0)
-    )
+    let appState = AppState()
+    appState.diagnosisHistory = [
+        DiagnosisRecord(
+            species: "dog",
+            symptoms: "lethargy",
+            wbc: "5",
+            rbc: "4",
+            glucose: "100",
+            result: "Possible anemia",
+            confidence: "70%"
+        )
+    ]
+    return HomeView(selectedTab: .constant(0)).environmentObject(appState)
 }

--- a/VetAI/ScanView.swift
+++ b/VetAI/ScanView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 struct ScanView: View {
-    @Binding var diagnosisHistory: [DiagnosisRecord]
+    @EnvironmentObject var appState: AppState
     @State private var species: String = "dog"
     @State private var symptoms: String = ""
     @State private var wbc: String = ""
@@ -48,7 +48,7 @@ struct ScanView: View {
                     result: diagnosis,
                     confidence: confidence
                 )
-                diagnosisHistory.append(record)
+                appState.diagnosisHistory.append(record)
             }
 
             if !diagnosis.isEmpty {
@@ -62,5 +62,5 @@ struct ScanView: View {
 }
 
 #Preview {
-    ScanView(diagnosisHistory: .constant([]))
+    ScanView().environmentObject(AppState())
 }


### PR DESCRIPTION
## Summary
- Remove diagnosisHistory bindings and rely on shared AppState
- Pass selectedTab only to HomeView, using AppState for data
- Update ScanView to append records to AppState

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689935de5c0083249989900530a0cb45