### PR TITLE
Simplify diagnosis record model

### DIFF
--- a/VetAI/AppState.swift
+++ b/VetAI/AppState.swift
@@ -16,14 +16,9 @@ struct Pet: Identifiable, Hashable {
 
 struct DiagnosisRecord: Identifiable {
     let id = UUID()
-    var petID: UUID? = nil
-    var species: String
-    var symptoms: String
-    var wbc: String
-    var rbc: String
-    var glucose: String
     var result: String
-    var confidence: String
+    var confidence: Double
     var date: Date = Date()
+    var petID: UUID? = nil
 }
 

--- a/VetAI/DiagnosisDetailView.swift
+++ b/VetAI/DiagnosisDetailView.swift
@@ -5,16 +5,10 @@ struct DiagnosisDetailView: View {
 
     var body: some View {
         Form {
-            Section(header: Text("Inputs")) {
-                HStack { Text("Species"); Spacer(); Text(record.species) }
-                HStack { Text("Symptoms"); Spacer(); Text(record.symptoms) }
-                HStack { Text("WBC"); Spacer(); Text(record.wbc) }
-                HStack { Text("RBC"); Spacer(); Text(record.rbc) }
-                HStack { Text("Glucose"); Spacer(); Text(record.glucose) }
-            }
             Section(header: Text("Diagnosis")) {
                 HStack { Text("Result"); Spacer(); Text(record.result) }
-                HStack { Text("Confidence"); Spacer(); Text(record.confidence) }
+                HStack { Text("Confidence"); Spacer(); Text(record.confidence, format: .percent) }
+                HStack { Text("Date"); Spacer(); Text(record.date, style: .date) }
             }
         }
         .navigationTitle("Diagnosis Detail")
@@ -22,5 +16,5 @@ struct DiagnosisDetailView: View {
 }
 
 #Preview {
-    DiagnosisDetailView(record: DiagnosisRecord(species: "dog", symptoms: "lethargy", wbc: "5", rbc: "4", glucose: "100", result: "Possible anemia", confidence: "70%"))
+    DiagnosisDetailView(record: DiagnosisRecord(result: "Possible anemia", confidence: 0.7))
 }

--- a/VetAI/HomeView.swift
+++ b/VetAI/HomeView.swift
@@ -15,8 +15,8 @@ struct HomeView: View {
                     if let lastRecord = appState.diagnosisHistory.last {
                         Section {
                             VStack(alignment: .leading) {
-                                Text(lastRecord.species)
                                 Text(lastRecord.result)
+                                Text(lastRecord.date, style: .date)
                                     .font(.subheadline)
                                     .foregroundColor(.secondary)
                             }
@@ -26,8 +26,8 @@ struct HomeView: View {
                     ForEach(appState.diagnosisHistory) { record in
                         NavigationLink(destination: DiagnosisDetailView(record: record)) {
                             VStack(alignment: .leading) {
-                                Text(record.species)
                                 Text(record.result)
+                                Text(record.date, style: .date)
                                     .font(.subheadline)
                                     .foregroundColor(.secondary)
                             }
@@ -50,13 +50,8 @@ struct HomeView: View {
     let appState = AppState()
     appState.diagnosisHistory = [
         DiagnosisRecord(
-            species: "dog",
-            symptoms: "lethargy",
-            wbc: "5",
-            rbc: "4",
-            glucose: "100",
             result: "Possible anemia",
-            confidence: "70%"
+            confidence: 0.7
         )
     ]
     return HomeView(selectedTab: .constant(0)).environmentObject(appState)

--- a/VetAI/ScanView.swift
+++ b/VetAI/ScanView.swift
@@ -7,8 +7,8 @@ struct ScanView: View {
     @State private var wbc: String = ""
     @State private var rbc: String = ""
     @State private var glucose: String = ""
-    @State private var diagnosis: String = ""
-    @State private var confidence: String = ""
+    @State private var result: String = ""
+    @State private var confidence: Double = 0
 
     var body: some View {
         Form {
@@ -32,29 +32,24 @@ struct ScanView: View {
 
             Button("Analyze") {
                 if symptoms.lowercased().contains("lethargy") {
-                    diagnosis = "Possible anemia"
-                    confidence = "70%"
+                    result = "Possible anemia"
+                    confidence = 0.7
                 } else {
-                    diagnosis = "No specific diagnosis"
-                    confidence = "N/A"
+                    result = "No specific diagnosis"
+                    confidence = 0
                 }
 
                 let record = DiagnosisRecord(
-                    species: species,
-                    symptoms: symptoms,
-                    wbc: wbc,
-                    rbc: rbc,
-                    glucose: glucose,
-                    result: diagnosis,
+                    result: result,
                     confidence: confidence
                 )
                 appState.diagnosisHistory.append(record)
             }
 
-            if !diagnosis.isEmpty {
+            if !result.isEmpty {
                 VStack(alignment: .leading) {
-                    Text("Diagnosis: \(diagnosis)")
-                    Text("Confidence: \(confidence)")
+                    Text("Diagnosis: \(result)")
+                    Text("Confidence: \(confidence, format: .percent)")
                 }
             }
         }


### PR DESCRIPTION
## Summary
- replace DiagnosisRecord properties with result, confidence, date, petID
- update detail, home, and scan views to use new fields

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_6899383752548324916e49a2e71d1e3b