### PR TITLE
Add dynamic greeting and latest diagnosis summary

### DIFF
--- a/VetAI/AppState.swift
+++ b/VetAI/AppState.swift
@@ -16,6 +16,7 @@ struct Pet: Identifiable, Hashable {
 
 struct DiagnosisRecord: Identifiable {
     let id = UUID()
+    var species: String
     var result: String
     var confidence: Double
     var date: Date = Date()

--- a/VetAI/DiagnosisDetailView.swift
+++ b/VetAI/DiagnosisDetailView.swift
@@ -6,6 +6,7 @@ struct DiagnosisDetailView: View {
     var body: some View {
         Form {
             Section(header: Text("Diagnosis")) {
+                HStack { Text("Species"); Spacer(); Text(record.species) }
                 HStack { Text("Result"); Spacer(); Text(record.result) }
                 HStack { Text("Confidence"); Spacer(); Text(record.confidence, format: .percent) }
                 HStack { Text("Date"); Spacer(); Text(record.date, style: .date) }
@@ -16,5 +17,5 @@ struct DiagnosisDetailView: View {
 }
 
 #Preview {
-    DiagnosisDetailView(record: DiagnosisRecord(result: "Possible anemia", confidence: 0.7))
+    DiagnosisDetailView(record: DiagnosisRecord(species: "dog", result: "Possible anemia", confidence: 0.7))
 }

--- a/VetAI/HomeView.swift
+++ b/VetAI/HomeView.swift
@@ -9,12 +9,14 @@ struct HomeView: View {
             VStack {
                 List {
                     Section {
-                        Text("Welcome back, Olivia!")
+                        Text(appState.ownerName.isEmpty ? "Welcome back!" : "Welcome back, \(appState.ownerName)!")
                     }
 
                     if let lastRecord = appState.diagnosisHistory.last {
                         Section {
                             VStack(alignment: .leading) {
+                                Text(lastRecord.species.capitalized)
+                                    .font(.headline)
                                 Text(lastRecord.result)
                                 Text(lastRecord.date, style: .date)
                                     .font(.subheadline)
@@ -26,6 +28,8 @@ struct HomeView: View {
                     ForEach(appState.diagnosisHistory) { record in
                         NavigationLink(destination: DiagnosisDetailView(record: record)) {
                             VStack(alignment: .leading) {
+                                Text(record.species.capitalized)
+                                    .font(.headline)
                                 Text(record.result)
                                 Text(record.date, style: .date)
                                     .font(.subheadline)
@@ -50,6 +54,7 @@ struct HomeView: View {
     let appState = AppState()
     appState.diagnosisHistory = [
         DiagnosisRecord(
+            species: "dog",
             result: "Possible anemia",
             confidence: 0.7
         )

--- a/VetAI/ScanView.swift
+++ b/VetAI/ScanView.swift
@@ -40,6 +40,7 @@ struct ScanView: View {
                 }
 
                 let record = DiagnosisRecord(
+                    species: species,
                     result: result,
                     confidence: confidence
                 )


### PR DESCRIPTION
## Summary
- Track diagnosis species via updated `DiagnosisRecord`
- Show owner-specific greeting and latest diagnosis details on home tab
- Persist species when creating new diagnoses for accurate history

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories)*

------
https://chatgpt.com/codex/tasks/task_e_68993a8e91ec83248beab9462640f74c