### PR TITLE
Rename diagnosis fields and show pet info

### DIFF
--- a/VetAI/AppState.swift
+++ b/VetAI/AppState.swift
@@ -17,8 +17,8 @@ struct Pet: Identifiable, Hashable {
 struct DiagnosisRecord: Identifiable {
     let id = UUID()
     var species: String
-    var result: String
-    var confidence: Double
+    var diagnosis: String
+    var confidenceScore: Int
     var date: Date = Date()
     var petID: UUID? = nil
 }

--- a/VetAI/DiagnosisDetailView.swift
+++ b/VetAI/DiagnosisDetailView.swift
@@ -2,13 +2,18 @@ import SwiftUI
 
 struct DiagnosisDetailView: View {
     let record: DiagnosisRecord
+    @EnvironmentObject var appState: AppState
 
     var body: some View {
         Form {
             Section(header: Text("Diagnosis")) {
+                if let petID = record.petID,
+                   let pet = appState.pets.first(where: { $0.id == petID }) {
+                    HStack { Text("Pet"); Spacer(); Text(pet.name) }
+                }
                 HStack { Text("Species"); Spacer(); Text(record.species) }
-                HStack { Text("Result"); Spacer(); Text(record.result) }
-                HStack { Text("Confidence"); Spacer(); Text(record.confidence, format: .percent) }
+                HStack { Text("Diagnosis"); Spacer(); Text(record.diagnosis) }
+                HStack { Text("Confidence"); Spacer(); Text("\(record.confidenceScore)%") }
                 HStack { Text("Date"); Spacer(); Text(record.date, style: .date) }
             }
         }
@@ -17,5 +22,7 @@ struct DiagnosisDetailView: View {
 }
 
 #Preview {
-    DiagnosisDetailView(record: DiagnosisRecord(species: "dog", result: "Possible anemia", confidence: 0.7))
+    DiagnosisDetailView(
+        record: DiagnosisRecord(species: "dog", diagnosis: "Possible anemia", confidenceScore: 70)
+    ).environmentObject(AppState())
 }

--- a/VetAI/HomeView.swift
+++ b/VetAI/HomeView.swift
@@ -15,9 +15,15 @@ struct HomeView: View {
                     if let lastRecord = appState.diagnosisHistory.last {
                         Section {
                             VStack(alignment: .leading) {
-                                Text(lastRecord.species.capitalized)
-                                    .font(.headline)
-                                Text(lastRecord.result)
+                                if let petID = lastRecord.petID,
+                                   let pet = appState.pets.first(where: { $0.id == petID }) {
+                                    Text(pet.name)
+                                        .font(.headline)
+                                } else {
+                                    Text(lastRecord.species.capitalized)
+                                        .font(.headline)
+                                }
+                                Text(lastRecord.diagnosis)
                                 Text(lastRecord.date, style: .date)
                                     .font(.subheadline)
                                     .foregroundColor(.secondary)
@@ -28,9 +34,15 @@ struct HomeView: View {
                     ForEach(appState.diagnosisHistory) { record in
                         NavigationLink(destination: DiagnosisDetailView(record: record)) {
                             VStack(alignment: .leading) {
-                                Text(record.species.capitalized)
-                                    .font(.headline)
-                                Text(record.result)
+                                if let petID = record.petID,
+                                   let pet = appState.pets.first(where: { $0.id == petID }) {
+                                    Text(pet.name)
+                                        .font(.headline)
+                                } else {
+                                    Text(record.species.capitalized)
+                                        .font(.headline)
+                                }
+                                Text(record.diagnosis)
                                 Text(record.date, style: .date)
                                     .font(.subheadline)
                                     .foregroundColor(.secondary)
@@ -55,8 +67,8 @@ struct HomeView: View {
     appState.diagnosisHistory = [
         DiagnosisRecord(
             species: "dog",
-            result: "Possible anemia",
-            confidence: 0.7
+            diagnosis: "Possible anemia",
+            confidenceScore: 70
         )
     ]
     return HomeView(selectedTab: .constant(0)).environmentObject(appState)

--- a/VetAI/ScanView.swift
+++ b/VetAI/ScanView.swift
@@ -7,8 +7,8 @@ struct ScanView: View {
     @State private var wbc: String = ""
     @State private var rbc: String = ""
     @State private var glucose: String = ""
-    @State private var result: String = ""
-    @State private var confidence: Double = 0
+    @State private var diagnosis: String = ""
+    @State private var confidenceScore: Int = 0
     @State private var selectedPet: Pet? = nil
 
     var body: some View {
@@ -40,17 +40,17 @@ struct ScanView: View {
 
             Button("Analyze") {
                 if symptoms.lowercased().contains("lethargy") {
-                    result = "Possible anemia"
-                    confidence = 0.7
+                    diagnosis = "Possible anemia"
+                    confidenceScore = 70
                 } else {
-                    result = "No specific diagnosis"
-                    confidence = 0
+                    diagnosis = "No specific diagnosis"
+                    confidenceScore = 0
                 }
 
                 let record = DiagnosisRecord(
                     species: species,
-                    result: result,
-                    confidence: confidence,
+                    diagnosis: diagnosis,
+                    confidenceScore: confidenceScore,
                     date: Date(),
                     petID: selectedPet?.id
                 )
@@ -64,10 +64,10 @@ struct ScanView: View {
                 selectedPet = nil
             }
 
-            if !result.isEmpty {
+            if !diagnosis.isEmpty {
                 VStack(alignment: .leading) {
-                    Text("Diagnosis: \(result)")
-                    Text("Confidence: \(confidence, format: .percent)")
+                    Text("Diagnosis: \(diagnosis)")
+                    Text("Confidence: \(confidenceScore)%")
                 }
             }
         }


### PR DESCRIPTION
## Summary
- rename diagnosis record fields and adjust types
- surface pet info for matching diagnosis records
- update scan workflow for new field names

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*
- `xcodebuild -list` *(fails: command not found: xcodebuild)*

------
https://chatgpt.com/codex/tasks/task_e_68993d93be8483249cf741308dba2fbd