### PR TITLE
Add lab labels and keyboard dismissal

### DIFF
--- a/VetAI/ScanView.swift
+++ b/VetAI/ScanView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct ScanView: View {
     @EnvironmentObject var appState: AppState
@@ -15,98 +16,109 @@ struct ScanView: View {
     @State private var selectedPet: Pet? = nil
 
     var body: some View {
-        Form {
-            Picker("Species", selection: $species) {
-                Text("Dog").tag("dog")
-                Text("Cat").tag("cat")
-                Text("Other").tag("other")
-            }
-
-            Picker("Pet", selection: $selectedPet) {
-                Text("No specific pet").tag(nil as Pet?)
-                ForEach(appState.pets) { pet in
-                    Text(pet.name).tag(Optional(pet))
-                }
-            }
-
-            Picker("WBC", selection: $wbcIsUnknown) {
-                Text("Unknown").tag(true)
-                Text("Enter value").tag(false)
-            }
-            .pickerStyle(SegmentedPickerStyle())
-            .onChange(of: wbcIsUnknown) { isUnknown in
-                if isUnknown { wbc = "" }
-            }
-            if !wbcIsUnknown {
-                TextField("WBC (×10⁹/L)", text: $wbc)
-                    .keyboardType(.decimalPad)
-            }
-
-            Picker("RBC", selection: $rbcIsUnknown) {
-                Text("Unknown").tag(true)
-                Text("Enter value").tag(false)
-            }
-            .pickerStyle(SegmentedPickerStyle())
-            .onChange(of: rbcIsUnknown) { isUnknown in
-                if isUnknown { rbc = "" }
-            }
-            if !rbcIsUnknown {
-                TextField("RBC (×10¹²/L)", text: $rbc)
-                    .keyboardType(.decimalPad)
-            }
-
-            Picker("Glucose", selection: $glucoseIsUnknown) {
-                Text("Unknown").tag(true)
-                Text("Enter value").tag(false)
-            }
-            .pickerStyle(SegmentedPickerStyle())
-            .onChange(of: glucoseIsUnknown) { isUnknown in
-                if isUnknown { glucose = "" }
-            }
-            if !glucoseIsUnknown {
-                TextField("Glucose (mg/dL)", text: $glucose)
-                    .keyboardType(.decimalPad)
-            }
-
-            Text("What are your pet’s symptoms?")
-            TextEditor(text: $symptoms)
-                .frame(minHeight: 100)
-
-            Button("Analyze") {
-                if symptoms.lowercased().contains("lethargy") {
-                    diagnosis = "Possible anemia"
-                    confidenceScore = 70
-                } else {
-                    diagnosis = "No specific diagnosis"
-                    confidenceScore = 0
+        ScrollView {
+            Form {
+                Picker("Species", selection: $species) {
+                    Text("Dog").tag("dog")
+                    Text("Cat").tag("cat")
+                    Text("Other").tag("other")
                 }
 
-                let record = DiagnosisRecord(
-                    species: species,
-                    diagnosis: diagnosis,
-                    confidenceScore: confidenceScore,
-                    date: Date(),
-                    petID: selectedPet?.id
-                )
-                appState.diagnosisHistory.append(record)
+                Picker("Pet", selection: $selectedPet) {
+                    Text("No specific pet").tag(nil as Pet?)
+                    ForEach(appState.pets) { pet in
+                        Text(pet.name).tag(Optional(pet))
+                    }
+                }
 
-                species = "dog"
-                symptoms = ""
-                wbc = ""
-                wbcIsUnknown = true
-                rbc = ""
-                rbcIsUnknown = true
-                glucose = ""
-                glucoseIsUnknown = true
-                selectedPet = nil
-            }
+                Text("WBC (×10⁹/L)")
+                    .font(.headline)
+                Picker("", selection: $wbcIsUnknown) {
+                    Text("Unknown").tag(true)
+                    Text("Enter value").tag(false)
+                }
+                .pickerStyle(SegmentedPickerStyle())
+                .onChange(of: wbcIsUnknown) { isUnknown in
+                    if isUnknown { wbc = "" }
+                }
+                if !wbcIsUnknown {
+                    TextField("Enter value", text: $wbc)
+                        .keyboardType(.decimalPad)
+                }
 
-            if !diagnosis.isEmpty {
-                VStack(alignment: .leading) {
-                    Text("Diagnosis: \(diagnosis)")
-                    Text("Confidence: \(confidenceScore)%")
+                Text("RBC (×10¹²/L)")
+                    .font(.headline)
+                Picker("", selection: $rbcIsUnknown) {
+                    Text("Unknown").tag(true)
+                    Text("Enter value").tag(false)
+                }
+                .pickerStyle(SegmentedPickerStyle())
+                .onChange(of: rbcIsUnknown) { isUnknown in
+                    if isUnknown { rbc = "" }
+                }
+                if !rbcIsUnknown {
+                    TextField("Enter value", text: $rbc)
+                        .keyboardType(.decimalPad)
+                }
+
+                Text("Glucose (mg/dL)")
+                    .font(.headline)
+                Picker("", selection: $glucoseIsUnknown) {
+                    Text("Unknown").tag(true)
+                    Text("Enter value").tag(false)
+                }
+                .pickerStyle(SegmentedPickerStyle())
+                .onChange(of: glucoseIsUnknown) { isUnknown in
+                    if isUnknown { glucose = "" }
+                }
+                if !glucoseIsUnknown {
+                    TextField("Enter value", text: $glucose)
+                        .keyboardType(.decimalPad)
+                }
+
+                Text("What are your pet’s symptoms?")
+                TextEditor(text: $symptoms)
+                    .frame(minHeight: 100)
+
+                Button("Analyze") {
+                    if symptoms.lowercased().contains("lethargy") {
+                        diagnosis = "Possible anemia"
+                        confidenceScore = 70
+                    } else {
+                        diagnosis = "No specific diagnosis"
+                        confidenceScore = 0
+                    }
+
+                    let record = DiagnosisRecord(
+                        species: species,
+                        diagnosis: diagnosis,
+                        confidenceScore: confidenceScore,
+                        date: Date(),
+                        petID: selectedPet?.id
+                    )
+                    appState.diagnosisHistory.append(record)
+
+                    species = "dog"
+                    symptoms = ""
+                    wbc = ""
+                    wbcIsUnknown = true
+                    rbc = ""
+                    rbcIsUnknown = true
+                    glucose = ""
+                    glucoseIsUnknown = true
+                    selectedPet = nil
+                }
+
+                if !diagnosis.isEmpty {
+                    VStack(alignment: .leading) {
+                        Text("Diagnosis: \(diagnosis)")
+                        Text("Confidence: \(confidenceScore)%")
+                    }
                 }
             }
+        }
+        .onTapGesture {
+            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
         }
     }
 }


### PR DESCRIPTION
## Summary
- add headline labels for WBC, RBC, and Glucose fields
- wrap form to dismiss keyboard when tapping outside inputs

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild -project VetAI.xcodeproj -scheme VetAI test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689943543b0c8324b45d60063ea8bcc1