### PR TITLE
Refactor ScanView form layout and keyboard dismissal

### DIFF
--- a/VetAI/ScanView.swift
+++ b/VetAI/ScanView.swift
@@ -14,111 +14,119 @@ struct ScanView: View {
     @State private var diagnosis: String = ""
     @State private var confidenceScore: Int = 0
     @State private var selectedPet: Pet? = nil
+    @FocusState private var isSymptomsFocused: Bool
 
     var body: some View {
-        ScrollView {
-            Form {
-                Picker("Species", selection: $species) {
-                    Text("Dog").tag("dog")
-                    Text("Cat").tag("cat")
-                    Text("Other").tag("other")
+        Form {
+            Picker("Species", selection: $species) {
+                Text("Dog").tag("dog")
+                Text("Cat").tag("cat")
+                Text("Other").tag("other")
+            }
+
+            Picker("Pet", selection: $selectedPet) {
+                Text("No specific pet").tag(nil as Pet?)
+                ForEach(appState.pets) { pet in
+                    Text(pet.name).tag(Optional(pet))
+                }
+            }
+
+            Text("WBC (×10⁹/L)")
+                .font(.headline)
+            Picker("", selection: $wbcIsUnknown) {
+                Text("Unknown").tag(true)
+                Text("Enter value").tag(false)
+            }
+            .pickerStyle(SegmentedPickerStyle())
+            .onChange(of: wbcIsUnknown) { isUnknown in
+                if isUnknown { wbc = "" }
+            }
+            if !wbcIsUnknown {
+                TextField("Enter value", text: $wbc)
+                    .keyboardType(.decimalPad)
+            }
+
+            Text("RBC (×10¹²/L)")
+                .font(.headline)
+            Picker("", selection: $rbcIsUnknown) {
+                Text("Unknown").tag(true)
+                Text("Enter value").tag(false)
+            }
+            .pickerStyle(SegmentedPickerStyle())
+            .onChange(of: rbcIsUnknown) { isUnknown in
+                if isUnknown { rbc = "" }
+            }
+            if !rbcIsUnknown {
+                TextField("Enter value", text: $rbc)
+                    .keyboardType(.decimalPad)
+            }
+
+            Text("Glucose (mg/dL)")
+                .font(.headline)
+            Picker("", selection: $glucoseIsUnknown) {
+                Text("Unknown").tag(true)
+                Text("Enter value").tag(false)
+            }
+            .pickerStyle(SegmentedPickerStyle())
+            .onChange(of: glucoseIsUnknown) { isUnknown in
+                if isUnknown { glucose = "" }
+            }
+            if !glucoseIsUnknown {
+                TextField("Enter value", text: $glucose)
+                    .keyboardType(.decimalPad)
+            }
+
+            Text("What are your pet’s symptoms?")
+            TextEditor(text: $symptoms)
+                .focused($isSymptomsFocused)
+                .frame(minHeight: 100)
+
+            Button("Analyze") {
+                if symptoms.lowercased().contains("lethargy") {
+                    diagnosis = "Possible anemia"
+                    confidenceScore = 70
+                } else {
+                    diagnosis = "No specific diagnosis"
+                    confidenceScore = 0
                 }
 
-                Picker("Pet", selection: $selectedPet) {
-                    Text("No specific pet").tag(nil as Pet?)
-                    ForEach(appState.pets) { pet in
-                        Text(pet.name).tag(Optional(pet))
-                    }
-                }
+                let record = DiagnosisRecord(
+                    species: species,
+                    diagnosis: diagnosis,
+                    confidenceScore: confidenceScore,
+                    date: Date(),
+                    petID: selectedPet?.id
+                )
+                appState.diagnosisHistory.append(record)
 
-                Text("WBC (×10⁹/L)")
-                    .font(.headline)
-                Picker("", selection: $wbcIsUnknown) {
-                    Text("Unknown").tag(true)
-                    Text("Enter value").tag(false)
-                }
-                .pickerStyle(SegmentedPickerStyle())
-                .onChange(of: wbcIsUnknown) { isUnknown in
-                    if isUnknown { wbc = "" }
-                }
-                if !wbcIsUnknown {
-                    TextField("Enter value", text: $wbc)
-                        .keyboardType(.decimalPad)
-                }
+                species = "dog"
+                symptoms = ""
+                wbc = ""
+                wbcIsUnknown = true
+                rbc = ""
+                rbcIsUnknown = true
+                glucose = ""
+                glucoseIsUnknown = true
+                selectedPet = nil
+            }
 
-                Text("RBC (×10¹²/L)")
-                    .font(.headline)
-                Picker("", selection: $rbcIsUnknown) {
-                    Text("Unknown").tag(true)
-                    Text("Enter value").tag(false)
-                }
-                .pickerStyle(SegmentedPickerStyle())
-                .onChange(of: rbcIsUnknown) { isUnknown in
-                    if isUnknown { rbc = "" }
-                }
-                if !rbcIsUnknown {
-                    TextField("Enter value", text: $rbc)
-                        .keyboardType(.decimalPad)
-                }
-
-                Text("Glucose (mg/dL)")
-                    .font(.headline)
-                Picker("", selection: $glucoseIsUnknown) {
-                    Text("Unknown").tag(true)
-                    Text("Enter value").tag(false)
-                }
-                .pickerStyle(SegmentedPickerStyle())
-                .onChange(of: glucoseIsUnknown) { isUnknown in
-                    if isUnknown { glucose = "" }
-                }
-                if !glucoseIsUnknown {
-                    TextField("Enter value", text: $glucose)
-                        .keyboardType(.decimalPad)
-                }
-
-                Text("What are your pet’s symptoms?")
-                TextEditor(text: $symptoms)
-                    .frame(minHeight: 100)
-
-                Button("Analyze") {
-                    if symptoms.lowercased().contains("lethargy") {
-                        diagnosis = "Possible anemia"
-                        confidenceScore = 70
-                    } else {
-                        diagnosis = "No specific diagnosis"
-                        confidenceScore = 0
-                    }
-
-                    let record = DiagnosisRecord(
-                        species: species,
-                        diagnosis: diagnosis,
-                        confidenceScore: confidenceScore,
-                        date: Date(),
-                        petID: selectedPet?.id
-                    )
-                    appState.diagnosisHistory.append(record)
-
-                    species = "dog"
-                    symptoms = ""
-                    wbc = ""
-                    wbcIsUnknown = true
-                    rbc = ""
-                    rbcIsUnknown = true
-                    glucose = ""
-                    glucoseIsUnknown = true
-                    selectedPet = nil
-                }
-
-                if !diagnosis.isEmpty {
-                    VStack(alignment: .leading) {
-                        Text("Diagnosis: \(diagnosis)")
-                        Text("Confidence: \(confidenceScore)%")
-                    }
+            if !diagnosis.isEmpty {
+                VStack(alignment: .leading) {
+                    Text("Diagnosis: \(diagnosis)")
+                    Text("Confidence: \(confidenceScore)%")
                 }
             }
         }
+        .scrollDismissesKeyboard(.interactively)
         .onTapGesture {
             UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Button("Done") {
+                    isSymptomsFocused = false
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace outer ScrollView with a single Form
- manage keyboard focus via @FocusState and toolbar "Done" button
- dismiss keyboard interactively and on tap

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_689bff1b5a8483249b8957900a47aad8