### PR TITLE
Apply primary tint and inline tab styling

### DIFF
--- a/VetAI/ContentView.swift
+++ b/VetAI/ContentView.swift
@@ -8,21 +8,33 @@ struct ContentView: View {
             HomeView(selectedTab: $selectedTab)
                 .tabItem {
                     Label("Home", systemImage: "house")
+                        .foregroundColor(selectedTab == 0 ? Palette.primary : Palette.cyanDark.opacity(0.6))
                 }
                 .tag(0)
 
-            ScanView()
-                .tabItem {
-                    Label("AI Diagnosis", systemImage: "stethoscope")
-                }
-                .tag(1)
+            NavigationStack {
+                ScanView()
+                    .navigationTitle("AI Diagnosis")
+                    .navigationBarTitleDisplayMode(.inline)
+            }
+            .tabItem {
+                Label("AI Diagnosis", systemImage: "stethoscope")
+                    .foregroundColor(selectedTab == 1 ? Palette.primary : Palette.cyanDark.opacity(0.6))
+            }
+            .tag(1)
 
-            ProfileView()
-                .tabItem {
-                    Label("Profile", systemImage: "person")
-                }
-                .tag(2)
+            NavigationStack {
+                ProfileView()
+                    .navigationTitle("Profile")
+                    .navigationBarTitleDisplayMode(.inline)
+            }
+            .tabItem {
+                Label("Profile", systemImage: "person")
+                    .foregroundColor(selectedTab == 2 ? Palette.primary : Palette.cyanDark.opacity(0.6))
+            }
+            .tag(2)
         }
+        .tint(Palette.primary)
     }
 }
 

--- a/VetAI/HomeView.swift
+++ b/VetAI/HomeView.swift
@@ -58,6 +58,7 @@ struct HomeView: View {
                 .padding()
             }
             .navigationTitle("History")
+            .navigationBarTitleDisplayMode(.inline)
         }
     }
 }

--- a/VetAI/VetAIApp.swift
+++ b/VetAI/VetAIApp.swift
@@ -5,7 +5,9 @@ struct VetAIApp: App {
     @StateObject private var appState = AppState()
     var body: some Scene {
         WindowGroup {
-            ContentView().environmentObject(appState)
+            ContentView()
+                .environmentObject(appState)
+                .tint(Palette.primary)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Apply Palette.primary tint to app root and TabView
- Style TabView items and navigation bars for consistent look

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689d2906bb348324ad92b7bb50d615ef