### PR TITLE
Improve dynamic colors and contrast

### DIFF
--- a/VetAI/Components/Card.swift
+++ b/VetAI/Components/Card.swift
@@ -1,13 +1,19 @@
 import SwiftUI
 
 struct Card: ViewModifier {
+    @Environment(\.colorScheme) private var colorScheme
+
     func body(content: Content) -> some View {
         content
             .background(
                 Color(light: Palette.surface, dark: Palette.surfaceAlt)
             )
             .cornerRadius(16)
-            .shadow(color: Color.black.opacity(0.1), radius: 4, x: 0, y: 2)
+            .shadow(color: shadowColor, radius: 4, x: 0, y: 2)
+    }
+
+    private var shadowColor: Color {
+        colorScheme == .dark ? Color.white.opacity(0.15) : Color.black.opacity(0.1)
     }
 }
 

--- a/VetAI/Components/PrimaryButtonStyle.swift
+++ b/VetAI/Components/PrimaryButtonStyle.swift
@@ -1,15 +1,22 @@
 import SwiftUI
 
-struct PrimaryButtonStyle: ButtonStyle {
-    func makeBody(configuration: Configuration) -> some View {
-        configuration.label
-            .font(Typography.button)
-            .padding(.vertical, 12)
-            .padding(.horizontal, 20)
-            .foregroundColor(.white)
-            .background(
-                Palette.primary.opacity(configuration.isPressed ? 0.9 : 1)
-            )
-            .cornerRadius(12)
+    struct PrimaryButtonStyle: ButtonStyle {
+        @Environment(\.colorScheme) private var colorScheme
+
+        func makeBody(configuration: Configuration) -> some View {
+            configuration.label
+                .font(Typography.button)
+                .padding(.vertical, 12)
+                .padding(.horizontal, 20)
+                .foregroundColor(.white)
+                .background(
+                    Palette.primary.opacity(configuration.isPressed ? 0.9 : 1)
+                )
+                .cornerRadius(12)
+                .shadow(color: shadowColor, radius: 2, x: 0, y: 2)
+        }
+
+        private var shadowColor: Color {
+            colorScheme == .dark ? Color.white.opacity(0.15) : Color.black.opacity(0.2)
+        }
     }
-}

--- a/VetAI/Components/SectionHeader.swift
+++ b/VetAI/Components/SectionHeader.swift
@@ -6,7 +6,7 @@ struct SectionHeader: View {
     var body: some View {
         Text(title)
             .font(Typography.section)
-            .foregroundColor(Palette.cyanDark)
+            .foregroundColor(.primary)
             .frame(maxWidth: .infinity, alignment: .leading)
     }
 }

--- a/VetAI/ContentView.swift
+++ b/VetAI/ContentView.swift
@@ -7,8 +7,8 @@ struct ContentView: View {
         TabView(selection: $selectedTab) {
             HomeView(selectedTab: $selectedTab)
                 .tabItem {
-                    Label("Home", systemImage: "house")
-                        .foregroundColor(selectedTab == 0 ? Palette.primary : Palette.cyanDark.opacity(0.6))
+                      Label("Home", systemImage: "house")
+                          .foregroundColor(selectedTab == 0 ? .primary : .secondary)
                 }
                 .tag(0)
 
@@ -18,8 +18,8 @@ struct ContentView: View {
                     .navigationBarTitleDisplayMode(.inline)
             }
             .tabItem {
-                Label("AI Diagnosis", systemImage: "stethoscope")
-                    .foregroundColor(selectedTab == 1 ? Palette.primary : Palette.cyanDark.opacity(0.6))
+                  Label("AI Diagnosis", systemImage: "stethoscope")
+                      .foregroundColor(selectedTab == 1 ? .primary : .secondary)
             }
             .tag(1)
 
@@ -29,8 +29,8 @@ struct ContentView: View {
                     .navigationBarTitleDisplayMode(.inline)
             }
             .tabItem {
-                Label("Profile", systemImage: "person")
-                    .foregroundColor(selectedTab == 2 ? Palette.primary : Palette.cyanDark.opacity(0.6))
+                  Label("Profile", systemImage: "person")
+                      .foregroundColor(selectedTab == 2 ? .primary : .secondary)
             }
             .tag(2)
         }

--- a/VetAI/HomeView.swift
+++ b/VetAI/HomeView.swift
@@ -26,8 +26,8 @@ struct HomeView: View {
                                     Text(lastRecord.species.capitalized)
                                         .font(.headline)
                                 }
-                                Text(lastRecord.diagnosis)
-                                    .foregroundColor(Palette.blueAccent)
+                                  Text(lastRecord.diagnosis)
+                                      .foregroundColor(.primary)
                                 Text(lastRecord.date, style: .date)
                                     .font(.subheadline)
                                     .foregroundColor(.secondary)

--- a/VetAI/ScanView.swift
+++ b/VetAI/ScanView.swift
@@ -37,9 +37,9 @@ struct ScanView: View {
 
             SectionHeader(title: "Labs")
 
-            Text("WBC (×10⁹/L)")
-                .font(Typography.section)
-                .foregroundColor(Palette.cyanDark)
+              Text("WBC (×10⁹/L)")
+                  .font(Typography.section)
+                  .foregroundColor(.primary)
             Picker("", selection: $wbcIsUnknown) {
                 Text("Unknown").tag(true)
                 Text("Enter value").tag(false)
@@ -54,9 +54,9 @@ struct ScanView: View {
                     .font(Typography.body)
             }
 
-            Text("RBC (×10¹²/L)")
-                .font(Typography.section)
-                .foregroundColor(Palette.cyanDark)
+              Text("RBC (×10¹²/L)")
+                  .font(Typography.section)
+                  .foregroundColor(.primary)
             Picker("", selection: $rbcIsUnknown) {
                 Text("Unknown").tag(true)
                 Text("Enter value").tag(false)
@@ -71,9 +71,9 @@ struct ScanView: View {
                     .font(Typography.body)
             }
 
-            Text("Glucose (mg/dL)")
-                .font(Typography.section)
-                .foregroundColor(Palette.cyanDark)
+              Text("Glucose (mg/dL)")
+                  .font(Typography.section)
+                  .foregroundColor(.primary)
             Picker("", selection: $glucoseIsUnknown) {
                 Text("Unknown").tag(true)
                 Text("Enter value").tag(false)

--- a/VetAI/Theme/Theme.swift
+++ b/VetAI/Theme/Theme.swift
@@ -9,7 +9,25 @@ enum Palette {
     static let surface = Color("Surface")
     static let cyanDark = Color("CyanDark") // TODO: refine hex
     static let blueAccent = Color("BlueAccent") // TODO: refine hex
-    static let surfaceAlt = Color(light: .init(white: 0.97), dark: .init(white: 0.12))
+    static let surfaceAlt: Color = {
+        #if canImport(UIKit)
+        return Color(UIColor { traits in
+            if traits.userInterfaceStyle == .dark {
+                let base = UIColor.systemBackground
+                var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+                base.getRed(&r, green: &g, blue: &b, alpha: &a)
+                return UIColor(red: min(r + 0.12, 1),
+                                green: min(g + 0.12, 1),
+                                blue: min(b + 0.12, 1),
+                                alpha: a)
+            } else {
+                return UIColor(white: 0.97, alpha: 1)
+            }
+        })
+        #else
+        return Color(white: 0.97)
+        #endif
+    }()
 }
 
 enum Typography {


### PR DESCRIPTION
## Summary
- Implement dynamic `surfaceAlt` color that lightens `systemBackground` in dark mode
- Standardize text colors to `.primary`/`.secondary`
- Tune card and button shadows for better light/dark contrast

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_689fafe62e148324a23a9e50df7dd7ef