### PR TITLE
Refine ScanView keyboard handling and toolbar layout

### DIFF
--- a/VetAI/ScanView.swift
+++ b/VetAI/ScanView.swift
@@ -122,6 +122,7 @@ struct ScanView: View {
                 glucose = ""
                 glucoseIsUnknown = true
                 selectedPet = nil
+                isSymptomsFocused = false
             }
             .buttonStyle(PrimaryButtonStyle())
 
@@ -135,11 +136,9 @@ struct ScanView: View {
             }
         }
         .scrollDismissesKeyboard(.interactively)
-        .onTapGesture {
-            UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
-        }
         .toolbar {
             ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
                 Button("Done") {
                     isSymptomsFocused = false
                 }


### PR DESCRIPTION
## Summary
- Remove top-level tap gesture so taps reach child controls
- Add spacer in keyboard toolbar to align Done button to the right
- Clear text field focus after Analyze action to dismiss keyboard

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68a8684d0b0c8324af88ab7c9f94216f