### PR TITLE
Improve keyboard management in ProfileView

### DIFF
--- a/VetAI/ProfileView.swift
+++ b/VetAI/ProfileView.swift
@@ -5,32 +5,44 @@ struct ProfileView: View {
     @State private var petName = ""
     @State private var petSpecies = ""
     @State private var petAge = ""
+    @FocusState private var focusedField: Field?
+
+    enum Field {
+        case ownerName, ownerEmail, petName, petSpecies, petAge
+    }
 
     var body: some View {
         List {
             Section(header: SectionHeader(title: "User Info")) {
                 TextField("Name", text: $appState.ownerName)
                     .font(Typography.body)
+                    .focused($focusedField, equals: .ownerName)
                 TextField("Email", text: $appState.ownerEmail)
                     .font(Typography.body)
+                    .focused($focusedField, equals: .ownerEmail)
             }
             .listRowBackground(Palette.surfaceAlt)
 
             Section(header: SectionHeader(title: "Add Pet")) {
                 TextField("Pet Name", text: $petName)
                     .font(Typography.body)
+                    .focused($focusedField, equals: .petName)
                 TextField("Species", text: $petSpecies)
                     .font(Typography.body)
+                    .focused($focusedField, equals: .petSpecies)
                 TextField("Age", text: $petAge)
                     .font(Typography.body)
+                    .focused($focusedField, equals: .petAge)
                 Button("Add Pet") {
-                    if let age = Int(petAge) {
-                        let pet = Pet(name: petName, species: petSpecies, age: age)
-                        appState.pets.append(pet)
-                        petName = ""
-                        petSpecies = ""
-                        petAge = ""
+                    guard !petName.isEmpty, !petSpecies.isEmpty, let age = Int(petAge) else {
+                        return
                     }
+                    let pet = Pet(name: petName, species: petSpecies, age: age)
+                    appState.pets.append(pet)
+                    petName = ""
+                    petSpecies = ""
+                    petAge = ""
+                    focusedField = nil
                 }
                 .buttonStyle(PrimaryButtonStyle())
             }
@@ -55,8 +67,15 @@ struct ProfileView: View {
             }
             .listRowBackground(Palette.surfaceAlt)
         }
+        .scrollDismissesKeyboard(.interactively)
         .scrollContentBackground(.hidden)
         .background(Palette.surfaceAlt)
+        .toolbar {
+            ToolbarItemGroup(placement: .keyboard) {
+                Spacer()
+                Button("Done") { focusedField = nil }
+            }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Manage focus across text fields using `@FocusState` and new `Field` enum
- Dismiss keyboard via scroll and toolbar with Done button
- Validate and reset pet fields when adding a pet

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f254291883248aa60fe86869da3e