### PR TITLE
Wrap navigationBarTitleDisplayMode in iOS checks

### DIFF
--- a/VetAI/ContentView.swift
+++ b/VetAI/ContentView.swift
@@ -15,7 +15,9 @@ struct ContentView: View {
             NavigationStack {
                 ScanView()
                     .navigationTitle("AI Diagnosis")
+                    #if os(iOS)
                     .navigationBarTitleDisplayMode(.inline)
+                    #endif
             }
             .tabItem {
                   Label("AI Diagnosis", systemImage: "stethoscope")
@@ -26,7 +28,9 @@ struct ContentView: View {
             NavigationStack {
                 ProfileView()
                     .navigationTitle("Profile")
+                    #if os(iOS)
                     .navigationBarTitleDisplayMode(.inline)
+                    #endif
             }
             .tabItem {
                   Label("Profile", systemImage: "person")


### PR DESCRIPTION
## Summary
- Guard navigationBarTitleDisplayMode modifier behind `#if os(iOS)` to maintain compatibility with macOS

## Testing
- `swift build` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68b13e3df10c832493e5a0237ad219c8