### PR TITLE
Guard navigation bar title display mode for iOS

### DIFF
--- a/VetAI/HomeView.swift
+++ b/VetAI/HomeView.swift
@@ -68,7 +68,9 @@ struct HomeView: View {
                 .padding()
             }
             .navigationTitle("History")
+            #if os(iOS)
             .navigationBarTitleDisplayMode(.inline)
+            #endif
         }
     }
 }


### PR DESCRIPTION
## Summary
- Guard `navigationBarTitleDisplayMode` with `#if os(iOS)` to avoid macOS build issues in `HomeView`

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -scheme VetAI -destination 'platform=iOS Simulator,name=iPhone 14' build` *(fails: command not found)*
- `xcodebuild -scheme VetAI -destination 'platform=macOS' build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b13fea4fac8324b08d6914d4e407f0