### PR TITLE
Wrap iOS-specific keyboard features in conditional compilation

### DIFF
--- a/VetAI/ProfileView.swift
+++ b/VetAI/ProfileView.swift
@@ -67,15 +67,19 @@ struct ProfileView: View {
             }
             .listRowBackground(Palette.surfaceAlt)
         }
+#if os(iOS)
         .scrollDismissesKeyboard(.interactively)
+#endif
         .scrollContentBackground(.hidden)
         .background(Palette.surfaceAlt)
+#if os(iOS)
         .toolbar {
             ToolbarItemGroup(placement: .keyboard) {
                 Spacer()
                 Button("Done") { focusedField = nil }
             }
         }
+#endif
     }
 }
 


### PR DESCRIPTION
## Summary
- Guard iOS-only keyboard dismiss behavior and toolbar under `#if os(iOS)`

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swiftc VetAI/ProfileView.swift -target x86_64-apple-macosx12.0` *(fails: unable to load standard library)*
- `swiftc VetAI/ProfileView.swift -target x86_64-apple-ios16.0-simulator` *(fails: unable to load standard library)*

------
https://chatgpt.com/codex/tasks/task_e_68b1422d8a208324ad9db6599f29b1f0