### PR TITLE
Replace card modifier with Card view container

### DIFF
--- a/VetAI/Components/Card.swift
+++ b/VetAI/Components/Card.swift
@@ -1,24 +1,23 @@
 import SwiftUI
 
-struct Card: ViewModifier {
-    @Environment(\.colorScheme) private var colorScheme
+/// A reusable container view that applies the app's card styling.
+///
+/// Usage:
+/// ```swift
+/// Card {
+///     VStack { ... }
+/// }
+/// ```
+struct Card<Content: View>: View {
+    /// The content displayed inside the card.
+    let content: () -> Content
 
-    func body(content: Content) -> some View {
-        content
-            .background(
-                Color(light: Palette.surface, dark: Palette.surfaceAlt)
-            )
-            .cornerRadius(16)
-            .shadow(color: shadowColor, radius: 4, x: 0, y: 2)
-    }
-
-    private var shadowColor: Color {
-        colorScheme == .dark ? Color.white.opacity(0.15) : Color.black.opacity(0.1)
-    }
-}
-
-extension View {
-    func card() -> some View {
-        modifier(Card())
+    var body: some View {
+        content()
+            .padding(Spacing.l)
+            .background(Palette.surface)
+            .cornerRadius(Radius.card)
+            .shadow(color: Shadow.card, radius: 12, x: 0, y: 6)
     }
 }
+

--- a/VetAI/HomeView.swift
+++ b/VetAI/HomeView.swift
@@ -8,14 +8,13 @@ struct HomeView: View {
         NavigationStack {
             VStack {
                 List {
-                    Section {
+                    Card {
                         Text(appState.ownerName.isEmpty ? "Welcome back!" : "Welcome back, \(appState.ownerName)!")
                     }
                     .listRowBackground(Color.clear)
-                    .card()
 
                     if let lastRecord = appState.diagnosisHistory.last {
-                        Section {
+                        Card {
                             SectionHeader(title: "Recent Diagnosis")
                             VStack(alignment: .leading) {
                                 if let petID = lastRecord.petID,
@@ -26,36 +25,36 @@ struct HomeView: View {
                                     Text(lastRecord.species.capitalized)
                                         .font(.headline)
                                 }
-                                  Text(lastRecord.diagnosis)
-                                      .foregroundColor(.primary)
+                                Text(lastRecord.diagnosis)
+                                    .foregroundColor(.primary)
                                 Text(lastRecord.date, style: .date)
                                     .font(.subheadline)
                                     .foregroundColor(.secondary)
                             }
                         }
                         .listRowBackground(Color.clear)
-                        .card()
                     }
 
                     ForEach(appState.diagnosisHistory) { record in
                         NavigationLink(destination: DiagnosisDetailView(record: record)) {
-                            VStack(alignment: .leading) {
-                                if let petID = record.petID,
-                                   let pet = appState.pets.first(where: { $0.id == petID }) {
-                                    Text(pet.name)
-                                        .font(.headline)
-                                } else {
-                                    Text(record.species.capitalized)
-                                        .font(.headline)
+                            Card {
+                                VStack(alignment: .leading) {
+                                    if let petID = record.petID,
+                                       let pet = appState.pets.first(where: { $0.id == petID }) {
+                                        Text(pet.name)
+                                            .font(.headline)
+                                    } else {
+                                        Text(record.species.capitalized)
+                                            .font(.headline)
+                                    }
+                                    Text(record.diagnosis)
+                                    Text(record.date, style: .date)
+                                        .font(.subheadline)
+                                        .foregroundColor(.secondary)
                                 }
-                                Text(record.diagnosis)
-                                Text(record.date, style: .date)
-                                    .font(.subheadline)
-                                    .foregroundColor(.secondary)
                             }
                         }
                         .listRowBackground(Color.clear)
-                        .card()
                     }
                 }
                 .scrollContentBackground(.hidden)

--- a/VetAI/Theme/Theme.swift
+++ b/VetAI/Theme/Theme.swift
@@ -35,18 +35,24 @@ struct Spacing {
     static let sm: CGFloat = 8
     static let md: CGFloat = 16
     static let lg: CGFloat = 24
+    // New naming used by modern components
+    static let l: CGFloat = 16
 }
 
 struct Radius {
     static let sm: CGFloat = 8
     static let md: CGFloat = 12
     static let lg: CGFloat = 16
+    // Radius used for card components
+    static let card: CGFloat = 16
 }
 
 struct Shadow {
     static let radius: CGFloat = 2
     static let x: CGFloat = 0
     static let y: CGFloat = 2
+    // Color token for card shadow
+    static let card = Color.black.opacity(0.1)
 }
 
 enum Typography {


### PR DESCRIPTION
## Summary
- replace Card view modifier with a generic `Card` view
- update HomeView to use `Card { ... }` instead of `.card()`
- add design tokens for spacing, radius and shadow

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b1453525088324a3611a988175274c