### PR TITLE
Refactor Card to use ViewBuilder content

### DIFF
--- a/VetAI/Components/Card.swift
+++ b/VetAI/Components/Card.swift
@@ -10,10 +10,14 @@ import SwiftUI
 /// ```
 struct Card<Content: View>: View {
     /// The content displayed inside the card.
-    let content: () -> Content
+    private let content: Content
+
+    init(@ViewBuilder content: () -> Content) {
+        self.content = content()
+    }
 
     var body: some View {
-        content()
+        content
             .padding(Spacing.l)
             .background(Palette.surface)
             .cornerRadius(Radius.card)


### PR DESCRIPTION
## Summary
- Refactor `Card` component to store its content as a view instead of a closure
- Add `@ViewBuilder` initializer so `Card` accepts multiple child views

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b18c12208c8324a7d360df67392aab