### PR TITLE
Refine SectionHeader styling

### DIFF
--- a/VetAI/Components/SectionHeader.swift
+++ b/VetAI/Components/SectionHeader.swift
@@ -6,7 +6,7 @@ struct SectionHeader: View {
     var body: some View {
         Text(title)
             .font(Typography.section)
-            .foregroundColor(.primary)
-            .frame(maxWidth: .infinity, alignment: .leading)
+            .foregroundStyle(Palette.cyanDark)
+            .padding(.bottom, 4)
     }
 }


### PR DESCRIPTION
## Summary
- use Palette.cyanDark for SectionHeader text
- add bottom padding for spacing
- remove frame alignment to let parent handle layout

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b1985292188324a33282ab3df9a6a2