### PR TITLE
Animate state changes and add haptic feedback

### DIFF
--- a/VetAI/HomeView.swift
+++ b/VetAI/HomeView.swift
@@ -73,6 +73,7 @@ struct HomeView: View {
                     }
                 }
                 .padding(Spacing.l)
+                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: appState.diagnosisHistory)
             }
             .background(Palette.surfaceAlt)
             .navigationTitle("History")

--- a/VetAI/ProfileView.swift
+++ b/VetAI/ProfileView.swift
@@ -50,6 +50,7 @@ struct ProfileView: View {
                         .frame(maxWidth: .infinity)
                 }
                 .padding(Spacing.l)
+                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: appState.pets)
             }
 #if os(iOS)
             .scrollDismissesKeyboard(.interactively)
@@ -77,6 +78,9 @@ struct ProfileView: View {
                               let age = Int(petAge) else { return }
                         let pet = Pet(name: petName, species: petSpecies, age: age)
                         appState.pets.append(pet)
+#if os(iOS)
+                        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+#endif
                         petName = ""
                         petSpecies = ""
                         petAge = ""

--- a/VetAI/ScanView.swift
+++ b/VetAI/ScanView.swift
@@ -33,6 +33,7 @@ struct ScanView: View {
                     Text(pet.name).tag(Optional(pet))
                 }
             }
+            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: appState.pets)
 
             SectionHeader("Labs")
 
@@ -137,6 +138,9 @@ struct ScanView: View {
                     petID: selectedPet?.id
                 )
                 appState.diagnosisHistory.append(record)
+#if os(iOS)
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+#endif
 
                 species = "dog"
                 symptoms = ""
@@ -167,6 +171,7 @@ struct ScanView: View {
                 }
             }
         }
+        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: diagnosis)
 #if os(iOS)
         .scrollDismissesKeyboard(.interactively)
         .toolbar {


### PR DESCRIPTION
## Summary
- Animate diagnosis history, pet list, and pet picker to react smoothly to state changes
- Trigger light haptics after analyzing and adding a pet on iOS

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b1a280a9108324afdd16a68fa8c408