### PR TITLE
Refactor animations and tidy greeting layout

### DIFF
--- a/VetAI/AppState.swift
+++ b/VetAI/AppState.swift
@@ -14,7 +14,7 @@ struct Pet: Identifiable, Hashable {
     var age: Int
 }
 
-struct DiagnosisRecord: Identifiable {
+struct DiagnosisRecord: Identifiable, Equatable {
     let id = UUID()
     var species: String
     var diagnosis: String

--- a/VetAI/HomeView.swift
+++ b/VetAI/HomeView.swift
@@ -12,10 +12,11 @@ struct HomeView: View {
                         VStack(alignment: .leading, spacing: Spacing.sm) {
                             if appState.ownerName.isEmpty {
                                 Text("Welcome back!")
+                                    .font(Typography.title)
                             } else {
                                 Text("Welcome back, \(appState.ownerName)!")
+                                    .font(Typography.title)
                             }
-                            .font(Typography.title)
                             Text("Ready for your next diagnosis?")
                                 .font(Typography.body)
                                 .foregroundColor(.secondary)
@@ -77,7 +78,6 @@ struct HomeView: View {
                     }
                 }
                 .padding(Spacing.l)
-                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: appState.diagnosisHistory)
             }
             .background(Palette.surfaceAlt)
             .navigationTitle("History")

--- a/VetAI/ProfileView.swift
+++ b/VetAI/ProfileView.swift
@@ -50,7 +50,6 @@ struct ProfileView: View {
                         .frame(maxWidth: .infinity)
                 }
                 .padding(Spacing.l)
-                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: appState.pets)
             }
 #if os(iOS)
             .scrollDismissesKeyboard(.interactively)
@@ -77,7 +76,9 @@ struct ProfileView: View {
                               !petSpecies.isEmpty,
                               let age = Int(petAge) else { return }
                         let pet = Pet(name: petName, species: petSpecies, age: age)
-                        appState.pets.append(pet)
+                        withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                            appState.pets.append(pet)
+                        }
 #if os(iOS)
                         UIImpactFeedbackGenerator(style: .light).impactOccurred()
 #endif

--- a/VetAI/ScanView.swift
+++ b/VetAI/ScanView.swift
@@ -33,7 +33,6 @@ struct ScanView: View {
                     Text(pet.name).tag(Optional(pet))
                 }
             }
-            .animation(.spring(response: 0.3, dampingFraction: 0.8), value: appState.pets)
 
             SectionHeader("Labs")
 
@@ -122,37 +121,39 @@ struct ScanView: View {
                 .frame(minHeight: 100)
 
             Button("Analyze") {
-                if symptoms.lowercased().contains("lethargy") {
-                    diagnosis = "Possible anemia"
-                    confidenceScore = 70
-                } else {
-                    diagnosis = "No specific diagnosis"
-                    confidenceScore = 0
-                }
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
+                    if symptoms.lowercased().contains("lethargy") {
+                        diagnosis = "Possible anemia"
+                        confidenceScore = 70
+                    } else {
+                        diagnosis = "No specific diagnosis"
+                        confidenceScore = 0
+                    }
 
-                let record = DiagnosisRecord(
-                    species: species,
-                    diagnosis: diagnosis,
-                    confidenceScore: confidenceScore,
-                    date: Date(),
-                    petID: selectedPet?.id
-                )
-                appState.diagnosisHistory.append(record)
+                    let record = DiagnosisRecord(
+                        species: species,
+                        diagnosis: diagnosis,
+                        confidenceScore: confidenceScore,
+                        date: Date(),
+                        petID: selectedPet?.id
+                    )
+                    appState.diagnosisHistory.append(record)
+
+                    species = "dog"
+                    symptoms = ""
+                    wbc = ""
+                    wbcIsUnknown = true
+                    rbc = ""
+                    rbcIsUnknown = true
+                    glucose = ""
+                    glucoseIsUnknown = true
+                    selectedPet = nil
+#if os(iOS)
+                    isSymptomsFocused = false
+#endif
+                }
 #if os(iOS)
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
-#endif
-
-                species = "dog"
-                symptoms = ""
-                wbc = ""
-                wbcIsUnknown = true
-                rbc = ""
-                rbcIsUnknown = true
-                glucose = ""
-                glucoseIsUnknown = true
-                selectedPet = nil
-#if os(iOS)
-                isSymptomsFocused = false
 #endif
             }
             .frame(maxWidth: .infinity)
@@ -171,7 +172,6 @@ struct ScanView: View {
                 }
             }
         }
-        .animation(.spring(response: 0.3, dampingFraction: 0.8), value: diagnosis)
 #if os(iOS)
         .scrollDismissesKeyboard(.interactively)
         .toolbar {


### PR DESCRIPTION
## Summary
- Apply title font separately to each greeting option in HomeView
- Allow comparison of diagnosis records by conforming to `Equatable`
- Replace view-wide `.animation` modifiers with targeted `withAnimation` blocks

## Testing
- `swift build` *(fails: Could not find Package.swift)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b226ee200c83248483c1cf1e4e132c