### PR TITLE
Add triage flow, LLM client, and validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+VetAI.xcconfig

--- a/VetAI/ContentView.swift
+++ b/VetAI/ContentView.swift
@@ -13,6 +13,19 @@ struct ContentView: View {
                 .tag(0)
 
             NavigationStack {
+                SymptomFormView()
+                    .navigationTitle("Triage")
+                    #if os(iOS)
+                    .navigationBarTitleDisplayMode(.inline)
+                    #endif
+            }
+            .tabItem {
+                  Label("Triage", systemImage: "list.bullet")
+                      .foregroundColor(selectedTab == 1 ? .primary : .secondary)
+            }
+            .tag(1)
+
+            NavigationStack {
                 ScanView()
                     .navigationTitle("AI Diagnosis")
                     #if os(iOS)
@@ -21,9 +34,9 @@ struct ContentView: View {
             }
             .tabItem {
                   Label("AI Diagnosis", systemImage: "stethoscope")
-                      .foregroundColor(selectedTab == 1 ? .primary : .secondary)
+                      .foregroundColor(selectedTab == 2 ? .primary : .secondary)
             }
-            .tag(1)
+            .tag(2)
 
             NavigationStack {
                 ProfileView()
@@ -34,9 +47,9 @@ struct ContentView: View {
             }
             .tabItem {
                   Label("Profile", systemImage: "person")
-                      .foregroundColor(selectedTab == 2 ? .primary : .secondary)
+                      .foregroundColor(selectedTab == 3 ? .primary : .secondary)
             }
-            .tag(2)
+            .tag(3)
         }
         .tint(Palette.primary)
     }

--- a/VetAI/LLM/PromptBuilder.swift
+++ b/VetAI/LLM/PromptBuilder.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+enum PromptBuilder {
+    static let system = "You are a helpful veterinary triage assistant."
+
+    static func user(from payload: CasePayload) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(payload) else { return "" }
+        return String(data: data, encoding: .utf8) ?? ""
+    }
+}

--- a/VetAI/Logging/VetLog.swift
+++ b/VetAI/Logging/VetLog.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum VetLog {
+    private static func redact(_ text: String) -> String {
+        var redacted = text
+        let emailPattern = "[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,}"
+        if let regex = try? NSRegularExpression(pattern: emailPattern, options: [.caseInsensitive]) {
+            let range = NSRange(location: 0, length: redacted.count)
+            redacted = regex.stringByReplacingMatches(in: redacted, options: [], range: range, withTemplate: "<redacted>")
+        }
+        if let apiKey = Bundle.main.infoDictionary?["OPENAI_API_KEY"] as? String, !apiKey.isEmpty {
+            redacted = redacted.replacingOccurrences(of: apiKey, with: "<redacted>")
+        }
+        return redacted
+    }
+
+    static func d(_ message: String) {
+        print("DEBUG: \(redact(message))")
+    }
+
+    static func e(_ message: String) {
+        print("ERROR: \(redact(message))")
+    }
+}

--- a/VetAI/Models/CaseModels.swift
+++ b/VetAI/Models/CaseModels.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+struct PetProfile: Codable {
+    var name: String
+    var species: String
+    var age: Int
+}
+
+struct Symptom: Codable, Identifiable {
+    let id = UUID()
+    var description: String
+    var durationDays: Int?
+}
+
+struct ExposuresRisks: Codable {
+    var toxins: [String]?
+    var travel: [String]?
+    var others: [String]?
+}
+
+struct CasePayload: Codable {
+    var pet: PetProfile
+    var symptoms: [Symptom]
+    var exposures: ExposuresRisks?
+}

--- a/VetAI/Models/TriageModels.swift
+++ b/VetAI/Models/TriageModels.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct Differential: Codable, Identifiable {
+    let id = UUID()
+    var condition: String
+    var confidencePct: Int
+}
+
+enum Urgency: String, Codable {
+    case low
+    case medium
+    case high
+    case unknown
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let raw = try container.decode(String.self)
+        self = Urgency(rawValue: raw) ?? .unknown
+    }
+}
+
+struct TriageResult: Codable {
+    var urgency: Urgency
+    var redFlags: [String]?
+    var differentials: [Differential]?
+    var homeCare: [String]?
+    var questions: [String]?
+    var disclaimer: String?
+}

--- a/VetAI/Networking/LLMClient.swift
+++ b/VetAI/Networking/LLMClient.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+struct ChatMessage: Codable {
+    let role: String
+    let content: String
+}
+
+struct ChatRequest: Codable {
+    let model: String
+    let messages: [ChatMessage]
+}
+
+struct ChatResponse: Codable {
+    struct Choice: Codable {
+        let message: ChatMessage
+    }
+    let choices: [Choice]
+}
+
+final class LLMClient {
+    static let shared = LLMClient()
+    private let session: URLSession
+
+    private init() {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 30
+        session = URLSession(configuration: config)
+    }
+
+    func send(messages: [ChatMessage]) async throws -> ChatResponse {
+        let apiKey = Bundle.main.infoDictionary?["OPENAI_API_KEY"] as? String ?? ""
+        var request = URLRequest(url: URL(string: "https://api.openai.com/v1/chat/completions")!)
+        request.httpMethod = "POST"
+        request.addValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(ChatRequest(model: "gpt-3.5-turbo", messages: messages))
+
+        var attempt = 0
+        let maxAttempts = 2
+        while attempt < maxAttempts {
+            attempt += 1
+            let start = Date()
+            do {
+                let (data, response) = try await session.data(for: request)
+                let duration = Date().timeIntervalSince(start)
+                VetLog.d("LLM round trip: \(duration)s")
+                guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                    throw URLError(.badServerResponse)
+                }
+                do {
+                    return try JSONDecoder().decode(ChatResponse.self, from: data)
+                } catch {
+                    VetLog.e("JSON decode error: \(error)")
+                    if attempt >= maxAttempts { throw error }
+                }
+            } catch {
+                VetLog.e("Request error: \(error)")
+                if attempt >= maxAttempts { throw error }
+            }
+        }
+        throw URLError(.badServerResponse)
+    }
+
+    func triage(_ payload: CasePayload) async throws -> TriageResult {
+        let userPrompt = PromptBuilder.user(from: payload)
+        let messages = [
+            ChatMessage(role: "system", content: PromptBuilder.system),
+            ChatMessage(role: "user", content: userPrompt)
+        ]
+        let response = try await send(messages: messages)
+        guard let content = response.choices.first?.message.content.data(using: .utf8) else {
+            throw URLError(.badServerResponse)
+        }
+        return try JSONDecoder().decode(TriageResult.self, from: content)
+    }
+}

--- a/VetAI/SymptomFormView.swift
+++ b/VetAI/SymptomFormView.swift
@@ -1,0 +1,123 @@
+import SwiftUI
+
+struct SymptomFormView: View {
+    @State private var symptomText: String = ""
+    @State private var isSubmitting = false
+    @State private var result: TriageResult? = nil
+    @State private var showToast = false
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading) {
+                TextEditor(text: $symptomText)
+                    .accessibilityIdentifier("symptomField")
+                    .frame(height: 200)
+                    .border(Color.gray)
+                NavigationLink(destination: ResultsView(result: result!), isActive: Binding<Bool>(
+                    get: { result != nil },
+                    set: { _ in }
+                )) { EmptyView() }
+                Button(action: submit) {
+                    if isSubmitting {
+                        ProgressView()
+                    } else {
+                        Text("Submit Symptoms")
+                    }
+                }
+                .disabled(isSubmitting)
+                .frame(maxWidth: .infinity)
+                .buttonStyle(PrimaryButtonStyle())
+                .padding(.top, 16)
+            }
+            .padding()
+            .navigationTitle("Symptoms")
+            .overlay(alignment: .bottom) {
+                if showToast {
+                    Text("Something went wrong")
+                        .padding()
+                        .background(Color.black.opacity(0.7))
+                        .foregroundColor(.white)
+                        .cornerRadius(8)
+                        .transition(.move(edge: .bottom))
+                        .padding()
+                }
+            }
+        }
+    }
+
+    private func submit() {
+        isSubmitting = true
+        let payload = CasePayload(
+            pet: PetProfile(name: "", species: "dog", age: 0),
+            symptoms: [Symptom(description: symptomText, durationDays: nil)],
+            exposures: nil
+        )
+        Task {
+            do {
+                let triage = try await LLMClient.shared.triage(payload)
+                result = triage
+            } catch {
+                withAnimation { showToast = true }
+                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                    withAnimation { showToast = false }
+                }
+            }
+            isSubmitting = false
+        }
+    }
+}
+
+struct ResultsView: View {
+    let result: TriageResult
+    @State private var showShare = false
+
+    var body: some View {
+        List {
+            Section("Urgency") { Text(result.urgency.rawValue.capitalized) }
+            if let red = result.redFlags {
+                Section("Red Flags") {
+                    ForEach(red, id: \.self) { Text($0) }
+                }
+            }
+            if let diffs = result.differentials {
+                Section("Differentials") {
+                    ForEach(diffs) { diff in
+                        HStack { Text(diff.condition); Spacer(); Text("\(diff.confidencePct)%") }
+                    }
+                }
+            }
+            if let home = result.homeCare {
+                Section("Home Care") {
+                    ForEach(home, id: \.self) { Text($0) }
+                }
+            }
+            if let questions = result.questions {
+                Section("Questions") {
+                    ForEach(questions, id: \.self) { q in
+                        Text(q)
+                            .onTapGesture {
+#if os(iOS)
+                                UIPasteboard.general.string = q
+#endif
+                            }
+                    }
+                }
+            }
+            if let disclaimer = result.disclaimer {
+                Section("Disclaimer") { Text(disclaimer) }
+            }
+        }
+        .navigationTitle("Results")
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button("Share") { showShare = true }
+            }
+        }
+        .sheet(isPresented: $showShare) {
+            let renderer = ImageRenderer(content: self)
+            if let img = renderer.uiImage {
+                ShareLink(item: img, preview: SharePreview("Triage"))
+            }
+        }
+    }
+}

--- a/VetAI/Validation/TriageResultValidator.swift
+++ b/VetAI/Validation/TriageResultValidator.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+enum TriageValidationError: Error {
+    case invalidUrgency
+    case tooManyDifferentials
+    case invalidConfidence
+    case missingField
+}
+
+struct TriageResultValidator {
+    func validate(_ result: TriageResult) throws {
+        guard result.urgency != .unknown else { throw TriageValidationError.invalidUrgency }
+        guard let diffs = result.differentials,
+              result.redFlags != nil,
+              result.homeCare != nil,
+              result.questions != nil else {
+            throw TriageValidationError.missingField
+        }
+        guard diffs.count <= 5 else { throw TriageValidationError.tooManyDifferentials }
+        for diff in diffs {
+            guard (0...100).contains(diff.confidencePct) else { throw TriageValidationError.invalidConfidence }
+        }
+    }
+}

--- a/VetAITests/TriageTests.swift
+++ b/VetAITests/TriageTests.swift
@@ -1,0 +1,38 @@
+import XCTest
+@testable import VetAI
+
+final class TriageTests: XCTestCase {
+    func testDecodeSample() throws {
+        let json = """
+        {
+            "urgency":"low",
+            "redFlags":["none"],
+            "differentials":[{"condition":"cold","confidencePct":50}],
+            "homeCare":["rest"],
+            "questions":["how long?"],
+            "disclaimer":"not for emergencies"
+        }
+        """
+        let data = json.data(using: .utf8)!
+        let result = try JSONDecoder().decode(TriageResult.self, from: data)
+        XCTAssertEqual(result.urgency, .low)
+        XCTAssertEqual(result.differentials?.count, 1)
+    }
+
+    func testValidatorRejectsBadUrgency() {
+        let bad = TriageResult(urgency: .unknown, redFlags: [], differentials: [], homeCare: [], questions: [], disclaimer: "")
+        let validator = TriageResultValidator()
+        XCTAssertThrowsError(try validator.validate(bad))
+    }
+
+    func testPromptBuilderHasFields() {
+        let payload = CasePayload(
+            pet: PetProfile(name: "Rex", species: "dog", age: 5),
+            symptoms: [Symptom(description: "cough", durationDays: nil)],
+            exposures: nil
+        )
+        let userPrompt = PromptBuilder.user(from: payload)
+        XCTAssertTrue(userPrompt.contains("pet"))
+        XCTAssertTrue(userPrompt.contains("symptoms"))
+    }
+}

--- a/VetAIUITests/SymptomFlowUITests.swift
+++ b/VetAIUITests/SymptomFlowUITests.swift
@@ -1,0 +1,15 @@
+import XCTest
+
+final class SymptomFlowUITests: XCTestCase {
+    func testSymptomSubmissionFlow() {
+        let app = XCUIApplication()
+        app.launch()
+
+        app.tabBars.buttons["Triage"].tap()
+        let field = app.textViews.matching(identifier: "symptomField").firstMatch
+        field.tap()
+        field.typeText("cough")
+        app.buttons["Submit Symptoms"].tap()
+        XCTAssertTrue(app.navigationBars["Results"].waitForExistence(timeout: 2))
+    }
+}


### PR DESCRIPTION
## Summary
- Define case and triage models for pet profile, symptoms, and LLM output
- Build prompt generator and OpenAI-backed LLM client with retry, logging, and validation
- Add SymptomForm and Results views with share/tap-to-copy and hook into tab bar

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b7742d51c083248f548b8da8941b47