### PR TITLE
Fix deprecated SwiftUI APIs and enable ShareLink image sharing

### DIFF
--- a/VetAI/Models/CaseModels.swift
+++ b/VetAI/Models/CaseModels.swift
@@ -7,7 +7,10 @@ struct PetProfile: Codable {
 }
 
 struct Symptom: Codable, Identifiable {
-    let id = UUID()
+    /// A unique identifier for the symptom. Using `var` instead of `let`
+    /// allows decoding to overwrite the value when needed, preventing
+    /// warnings about immutable properties during `Decodable` synthesis.
+    var id = UUID()
     var description: String
     var durationDays: Int?
 }

--- a/VetAI/ScanView.swift
+++ b/VetAI/ScanView.swift
@@ -44,7 +44,7 @@ struct ScanView: View {
                 Text("Enter value").tag(false)
             }
             .pickerStyle(SegmentedPickerStyle())
-            .onChange(of: wbcIsUnknown) { isUnknown in
+            .onChange(of: wbcIsUnknown) { _, isUnknown in
                 if isUnknown { wbc = "" }
             }
             if !wbcIsUnknown {
@@ -69,7 +69,7 @@ struct ScanView: View {
                 Text("Enter value").tag(false)
             }
             .pickerStyle(SegmentedPickerStyle())
-            .onChange(of: rbcIsUnknown) { isUnknown in
+            .onChange(of: rbcIsUnknown) { _, isUnknown in
                 if isUnknown { rbc = "" }
             }
             if !rbcIsUnknown {
@@ -94,7 +94,7 @@ struct ScanView: View {
                 Text("Enter value").tag(false)
             }
             .pickerStyle(SegmentedPickerStyle())
-            .onChange(of: glucoseIsUnknown) { isUnknown in
+            .onChange(of: glucoseIsUnknown) { _, isUnknown in
                 if isUnknown { glucose = "" }
             }
             if !glucoseIsUnknown {

--- a/VetAI/SymptomFormView.swift
+++ b/VetAI/SymptomFormView.swift
@@ -13,10 +13,6 @@ struct SymptomFormView: View {
                     .accessibilityIdentifier("symptomField")
                     .frame(height: 200)
                     .border(Color.gray)
-                NavigationLink(destination: ResultsView(result: result!), isActive: Binding<Bool>(
-                    get: { result != nil },
-                    set: { _ in }
-                )) { EmptyView() }
                 Button(action: submit) {
                     if isSubmitting {
                         ProgressView()
@@ -42,6 +38,9 @@ struct SymptomFormView: View {
                         .padding()
                 }
             }
+        }
+        .navigationDestination(item: $result) { result in
+            ResultsView(result: result)
         }
     }
 

--- a/VetAI/UIImage+Transferable.swift
+++ b/VetAI/UIImage+Transferable.swift
@@ -1,0 +1,14 @@
+import SwiftUI
+import UniformTypeIdentifiers
+#if canImport(UIKit)
+import UIKit
+
+// Allow UIImage to be shared via ShareLink by conforming to Transferable.
+extension UIImage: Transferable {
+    public static var transferRepresentation: some TransferRepresentation {
+        DataRepresentation(exportedContentType: .png) { image in
+            image.pngData() ?? Data()
+        }
+    }
+}
+#endif


### PR DESCRIPTION
## Summary
- Replace deprecated `NavigationLink` with modern `navigationDestination` API in symptom form
- Update `onChange` handlers to new two-parameter closure style
- Allow `UIImage` sharing via `ShareLink` by adding `Transferable` conformance
- Make Symptom model's `id` mutable to avoid decoding warnings

## Testing
- `swift test` *(fails: Could not find Package.swift)*
- `xcodebuild test -scheme VetAI` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b7766c73d08324979312dea9c402f7