### PR TITLE
Wrap triage section in scroll view

### DIFF
--- a/VetAI/TriageSection.swift
+++ b/VetAI/TriageSection.swift
@@ -7,24 +7,26 @@ struct TriageSection: View {
     @State private var showToast = false
 
     var body: some View {
-        VStack(alignment: .leading) {
-            TextEditor(text: $symptomText)
-                .accessibilityIdentifier("symptomField")
-                .frame(height: 200)
-                .border(Color.gray)
-            Button(action: submit) {
-                if isSubmitting {
-                    ProgressView()
-                } else {
-                    Text("Submit Symptoms")
+        ScrollView {
+            VStack(alignment: .leading) {
+                TextEditor(text: $symptomText)
+                    .accessibilityIdentifier("symptomField")
+                    .frame(height: 150)
+                    .border(Color.gray)
+                Button(action: submit) {
+                    if isSubmitting {
+                        ProgressView()
+                    } else {
+                        Text("Submit Symptoms")
+                    }
                 }
+                .disabled(isSubmitting)
+                .frame(maxWidth: .infinity)
+                .buttonStyle(PrimaryButtonStyle())
+                .padding(.top, 16)
             }
-            .disabled(isSubmitting)
-            .frame(maxWidth: .infinity)
-            .buttonStyle(PrimaryButtonStyle())
-            .padding(.top, 16)
+            .padding()
         }
-        .padding()
         .overlay(alignment: .bottom) {
             if showToast {
                 Text("Something went wrong")


### PR DESCRIPTION
## Summary
- Allow triage inputs to scroll by embedding them in a `ScrollView`
- Trim symptom editor height for a more compact triage form

## Testing
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68b7a8716d9483249fc8bde0eb2c0e81