### PR TITLE
Add TypeScript backend and iOS triage client

### DIFF
--- a/VetAI/Networking/VetAIAPI.swift
+++ b/VetAI/Networking/VetAIAPI.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+struct VetAIAPI {
+    struct TriageResult: Codable, Equatable {
+        let recommendation: String
+        let reasoning: String
+    }
+
+    let session: URLSession
+    let baseURL: URL
+    let token: String
+
+    init(session: URLSession = .shared, baseURL: URL = URL(string: "http://localhost:3000")!, token: String = "") {
+        self.session = session
+        self.baseURL = baseURL
+        self.token = token
+    }
+
+    func triage(casePayload: [String: Any]) async throws -> TriageResult {
+        var request = URLRequest(url: baseURL.appendingPathComponent("triage"))
+        request.httpMethod = "POST"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        if !token.isEmpty {
+            request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        request.httpBody = try JSONSerialization.data(withJSONObject: casePayload)
+
+        let (data, response) = try await session.data(for: request)
+        guard let http = response as? HTTPURLResponse, (200..<300).contains(http.statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+        return try JSONDecoder().decode(TriageResult.self, from: data)
+    }
+}

--- a/VetAITests/VetAIAPITests.swift
+++ b/VetAITests/VetAIAPITests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import VetAI
+
+final class VetAIAPITests: XCTestCase {
+    func testTriageDecodesERNow() async throws {
+        let json = """{\n  \"recommendation\": \"ER_NOW\",\n  \"reasoning\": \"Chocolate is toxic\"\n}""".data(using: .utf8)!
+        let url = URL(string: "http://localhost/triage")!
+        let session = URLSessionMock { _ in
+            let response = HTTPURLResponse(url: url, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (json, response)
+        }
+        let api = VetAIAPI(session: session, baseURL: URL(string: "http://localhost")!, token: "test")
+        let result = try await api.triage(casePayload: ["symptom": "ate chocolate"])
+        XCTAssertEqual(result.recommendation, "ER_NOW")
+    }
+}
+
+final class URLSessionMock: URLSession {
+    typealias Handler = (URLRequest) throws -> (Data, URLResponse)
+    let handler: Handler
+    init(handler: @escaping Handler) { self.handler = handler }
+    override func data(for request: URLRequest) async throws -> (Data, URLResponse) {
+        return try handler(request)
+    }
+}

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+OPENAI_API_KEY=your_openai_api_key
+DATABASE_URL=postgres://user:pass@localhost:5432/vetai

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,15 @@
+# VetAI Backend
+
+## Setup
+
+1. Copy `.env.example` to `.env` and fill in values for `OPENAI_API_KEY` and `DATABASE_URL`.
+2. Install dependencies: `npm install`.
+3. Run tests: `npm test`.
+4. Start server: `npm start`.
+
+The server exposes:
+
+- `POST /triage` accepting a `CasePayload` and returning a validated `TriageResult`.
+- `GET /cases?limit=20` returning recent cases for the authenticated user.
+
+Both endpoints require an `Authorization` header containing the user token.

--- a/backend/__tests__/triage.test.ts
+++ b/backend/__tests__/triage.test.ts
@@ -1,0 +1,33 @@
+import request from 'supertest';
+import { createApp, CasePayload, TriageResult } from '../index';
+import { newDb } from 'pg-mem';
+
+test('triage inserts case and returns ER_NOW', async () => {
+  const db = newDb();
+  const pg = db.adapters.createPg();
+  const pool = new pg.Pool();
+
+  const mockFetch = jest.fn().mockResolvedValue({
+    json: async () => ({
+      choices: [
+        {
+          message: { content: JSON.stringify({ recommendation: 'ER_NOW', reasoning: 'Chocolate is toxic' }) }
+        }
+      ]
+    })
+  });
+
+  const app = createApp({ pool, fetchImpl: mockFetch as any });
+  const payload: CasePayload = { species: 'dog', description: 'ate chocolate' };
+  const res = await request(app)
+    .post('/triage')
+    .set('Authorization', 'user1')
+    .send(payload);
+  expect(res.status).toBe(200);
+  const body: TriageResult = res.body;
+  expect(body.recommendation).toBe('ER_NOW');
+
+  const cases = await request(app).get('/cases').set('Authorization', 'user1');
+  expect(cases.body.length).toBe(1);
+  expect(cases.body[0].triage_result.recommendation).toBe('ER_NOW');
+});

--- a/backend/index.ts
+++ b/backend/index.ts
@@ -1,0 +1,122 @@
+import express, { Request, Response, NextFunction } from 'express';
+import Ajv, { JSONSchemaType } from 'ajv';
+import { Pool } from 'pg';
+
+export interface CasePayload {
+  species: string;
+  description: string;
+}
+
+export interface TriageResult {
+  recommendation: 'ER_NOW' | 'ER_SOON' | 'HOME_MONITOR';
+  reasoning: string;
+}
+
+const triageResultSchema: JSONSchemaType<TriageResult> = {
+  type: 'object',
+  properties: {
+    recommendation: { type: 'string', enum: ['ER_NOW', 'ER_SOON', 'HOME_MONITOR'] },
+    reasoning: { type: 'string' }
+  },
+  required: ['recommendation', 'reasoning'],
+  additionalProperties: false
+};
+
+const ajv = new Ajv();
+const validateTriage = ajv.compile(triageResultSchema);
+
+interface Deps {
+  pool?: Pool;
+  fetchImpl?: typeof fetch;
+}
+
+interface AuthedRequest extends Request {
+  userId?: string;
+}
+
+export function createApp({ pool, fetchImpl }: Deps = {}) {
+  const app = express();
+  app.use(express.json());
+
+  const db = pool ?? new Pool({ connectionString: process.env.DATABASE_URL });
+  const doFetch = fetchImpl ?? fetch;
+
+  async function initDb() {
+    await db.query(`CREATE TABLE IF NOT EXISTS users (id TEXT PRIMARY KEY);`);
+    await db.query(`CREATE TABLE IF NOT EXISTS pets (id SERIAL PRIMARY KEY, user_id TEXT REFERENCES users(id));`);
+    await db.query(`CREATE TABLE IF NOT EXISTS cases (
+      id SERIAL PRIMARY KEY,
+      user_id TEXT NOT NULL,
+      case_payload JSONB NOT NULL,
+      triage_result JSONB NOT NULL,
+      created_at TIMESTAMPTZ DEFAULT now()
+    );`);
+  }
+  initDb();
+
+  function auth(req: AuthedRequest, res: Response, next: NextFunction) {
+    const authHeader = req.header('authorization');
+    if (!authHeader) return res.status(401).send('Unauthorized');
+    req.userId = authHeader.replace('Bearer ', '');
+    next();
+  }
+
+  app.post('/triage', auth, async (req: AuthedRequest, res: Response) => {
+    const payload: CasePayload = req.body;
+    const messages = [
+      { role: 'system', content: 'You are a veterinary triage model. Return JSON matching schema.' },
+      { role: 'user', content: JSON.stringify(payload) }
+    ];
+
+    async function callModel(extra?: string) {
+      const body = {
+        model: 'gpt-4o-mini',
+        messages: extra ? [...messages, { role: 'user', content: extra }] : messages,
+        response_format: { type: 'json_object' }
+      };
+      const response = await doFetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${process.env.OPENAI_API_KEY}`
+        },
+        body: JSON.stringify(body)
+      });
+      const data = await response.json();
+      const content = data.choices?.[0]?.message?.content;
+      if (!content) return null;
+      try {
+        return JSON.parse(content);
+      } catch {
+        return null;
+      }
+    }
+
+    let result = await callModel();
+    if (!result || !validateTriage(result)) {
+      result = await callModel('return valid JSON per schema only');
+      if (!result || !validateTriage(result)) {
+        return res.status(500).json({ error: 'Model returned invalid response' });
+      }
+    }
+
+    await db.query('INSERT INTO cases (user_id, case_payload, triage_result) VALUES ($1, $2, $3)', [req.userId, payload, result]);
+    res.json(result);
+  });
+
+  app.get('/cases', auth, async (req: AuthedRequest, res: Response) => {
+    const limit = Number(req.query.limit ?? '20');
+    const { rows } = await db.query('SELECT * FROM cases WHERE user_id = $1 ORDER BY created_at DESC LIMIT $2', [req.userId, limit]);
+    res.json(rows);
+  });
+
+  return app;
+}
+
+if (require.main === module) {
+  const app = createApp();
+  const port = process.env.PORT || 3000;
+  app.listen(port, () => {
+    console.log(`Server running on ${port}`);
+  });
+}

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node'
+};

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "type": "commonjs",
+  "scripts": {
+    "start": "ts-node index.ts",
+    "test": "jest"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "ajv": "^8.12.0",
+    "pg": "^8.11.1"
+  },
+  "devDependencies": {
+    "typescript": "^5.6.3",
+    "ts-node": "^10.9.2",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1",
+    "@types/express": "^4.17.21",
+    "@types/jest": "^29.5.11",
+    "@types/node": "^20.11.30",
+    "supertest": "^6.3.3",
+    "pg-mem": "^3.0.5"
+  }
+}

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true
+  }
+}


### PR DESCRIPTION
## Summary
- build Express + TypeScript backend with OpenAI triage route and Postgres persistence
- add REST client on iOS plus URLSession-based triage call
- document environment variables and add basic tests

## Testing
- `npm test` *(fails: jest not found)*
- `xcodebuild -version` *(fails: command not found)*
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bae24e563483249f6c2ddf8412438b