### PR TITLE
Guard UIKit imports for cross-platform builds

### DIFF
--- a/VetAI/ScanView.swift
+++ b/VetAI/ScanView.swift
@@ -1,4 +1,8 @@
+#if canImport(SwiftUI)
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 struct ScanView: View {
     @EnvironmentObject var appState: AppState
@@ -190,6 +194,9 @@ struct ScanView: View {
     }
 }
 
+#if DEBUG
 #Preview {
     ScanView().environmentObject(AppState())
 }
+#endif
+#endif

--- a/VetAI/Theme/Theme.swift
+++ b/VetAI/Theme/Theme.swift
@@ -1,5 +1,5 @@
+#if canImport(SwiftUI)
 import SwiftUI
-
 #if canImport(UIKit)
 import UIKit
 #endif
@@ -76,3 +76,4 @@ extension Color {
         #endif
     }
 }
+#endif

--- a/VetAI/TransferableImage.swift
+++ b/VetAI/TransferableImage.swift
@@ -1,7 +1,7 @@
-import SwiftUI
-import UniformTypeIdentifiers
 #if canImport(UIKit)
+import SwiftUI
 import UIKit
+import UniformTypeIdentifiers
 
 /// Wrapper allowing ``UIImage`` instances to be used with ``ShareLink``.
 struct TransferableImage: Transferable {


### PR DESCRIPTION
## Summary
- conditionally import SwiftUI and UIKit in ScanView, Theme, and TransferableImage
- scope previews to DEBUG builds

## Testing
- `swiftc VetAI/ScanView.swift && echo 'ScanView compiled'`
- `swiftc VetAI/TransferableImage.swift && echo 'TransferableImage compiled'`
- `swiftc VetAI/Theme/Theme.swift && echo 'Theme compiled'`


------
https://chatgpt.com/codex/tasks/task_e_68baeb9ff57c8324ab63100674abce21