### PR TITLE
Remove UIKit dependency from ScanView

### DIFF
--- a/VetAI/ScanView.swift
+++ b/VetAI/ScanView.swift
@@ -1,8 +1,5 @@
 #if canImport(SwiftUI)
 import SwiftUI
-#if canImport(UIKit)
-import UIKit
-#endif
 
 struct ScanView: View {
     @EnvironmentObject var appState: AppState


### PR DESCRIPTION
## Summary
- remove UIKit import from ScanView since SwiftUI covers needed functionality

## Testing
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baff07561c8324b8bd8043b68e89ff