### PR TITLE
Fix platform-specific keyboard modifiers

### DIFF
--- a/VetAI/ProfileView.swift
+++ b/VetAI/ProfileView.swift
@@ -56,7 +56,7 @@ struct ProfileView: View {
                 }
                 .padding(Spacing.l)
             }
-#if os(iOS)
+#if canImport(UIKit)
             .scrollDismissesKeyboard(.interactively)
 #endif
             .background(Palette.surfaceAlt)
@@ -74,7 +74,7 @@ struct ProfileView: View {
                             .focused($focusedField, equals: .petSpecies)
                         TextField("Age", text: $petAge)
                             .font(Typography.body)
-#if os(iOS)
+#if canImport(UIKit)
                             .keyboardType(.numberPad)
 #endif
                             .focused($focusedField, equals: .petAge)
@@ -87,7 +87,7 @@ struct ProfileView: View {
                             withAnimation(.spring(response: 0.3, dampingFraction: 0.8)) {
                                 appState.pets.append(pet)
                             }
-#if os(iOS)
+#if canImport(UIKit)
                             UIImpactFeedbackGenerator(style: .light).impactOccurred()
 #endif
                             petName = ""
@@ -103,7 +103,7 @@ struct ProfileView: View {
                     }
                     .padding(Spacing.l)
                 }
-#if os(iOS)
+#if canImport(UIKit)
                 .scrollDismissesKeyboard(.interactively)
 #endif
                 .navigationTitle("Add Pet")

--- a/VetAI/ScanView.swift
+++ b/VetAI/ScanView.swift
@@ -1,5 +1,8 @@
 #if canImport(SwiftUI)
 import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#endif
 
 struct ScanView: View {
     @EnvironmentObject var appState: AppState
@@ -50,9 +53,11 @@ struct ScanView: View {
             }
             if !wbcIsUnknown {
                 HStack {
+#if canImport(UIKit)
                     TextField("e.g., 6.0", text: $wbc)
-#if os(iOS)
                         .keyboardType(.decimalPad)
+#else
+                    TextField("e.g., 6.0", text: $wbc)
 #endif
                         .font(Typography.body)
                     Spacer()
@@ -75,9 +80,11 @@ struct ScanView: View {
             }
             if !rbcIsUnknown {
                 HStack {
+#if canImport(UIKit)
                     TextField("e.g., 6.0", text: $rbc)
-#if os(iOS)
                         .keyboardType(.decimalPad)
+#else
+                    TextField("e.g., 6.0", text: $rbc)
 #endif
                         .font(Typography.body)
                     Spacer()
@@ -100,9 +107,11 @@ struct ScanView: View {
             }
             if !glucoseIsUnknown {
                 HStack {
+#if canImport(UIKit)
                     TextField("e.g., 6.0", text: $glucose)
-#if os(iOS)
                         .keyboardType(.decimalPad)
+#else
+                    TextField("e.g., 6.0", text: $glucose)
 #endif
                         .font(Typography.body)
                     Spacer()
@@ -131,7 +140,7 @@ struct ScanView: View {
             Button("Retry") { Task { await submit() } }
             Button("Cancel", role: .cancel) { }
         }
-#if os(iOS)
+#if canImport(UIKit)
         .scrollDismissesKeyboard(.interactively)
 #endif
     }


### PR DESCRIPTION
## Summary
- Guard keyboard-specific modifiers with `canImport(UIKit)` to avoid build errors on non-UIKit platforms
- Apply the same platform check for scroll dismissal and feedback generators
- Conditionally import UIKit in `ScanView` to prevent missing-module compilation errors

## Testing
- `swift test` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_68bb02ad2a088324afc3436db25b4d55